### PR TITLE
Declare package to be typed via to PEP 561

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,5 +23,6 @@ setup(
     url='https://github.com/lovasoa/marshmallow_dataclass',
     keywords=['marshmallow', 'dataclass', 'serialization'],
     classifiers=CLASSIFIERS,
-    install_requires=['marshmallow>=2.0,<3.0', 'typing-inspect']
+    install_requires=['marshmallow>=2.0,<3.0', 'typing-inspect'],
+    package_data={"marshmallow_dataclass": ["py.typed"]},
 )


### PR DESCRIPTION
Following https://mypy.readthedocs.io/en/latest/installed_packages.html allows users of marshmallow_dataclass to type check their code against the type declarations in marshmallow_dataclass.

While this works towards https://github.com/lovasoa/marshmallow_dataclass/issues/6, it does not solve it, since mypy does not understand how marshmallow_dataclass' `dataclass` decorator works. I don't know how that case can be solved.