### PR TITLE
Fix error message for unsupported types

### DIFF
--- a/marshmallow_dataclass/__init__.py
+++ b/marshmallow_dataclass/__init__.py
@@ -191,6 +191,11 @@ def class_schema(clazz: type) -> Type[marshmallow.Schema]:
     >>> _, err = class_schema(NeverValid)().load({})
     >>> err
     {'_schema': ['never valid']}
+
+    >>> class_schema(None)  # unsupported type
+    Traceback (most recent call last):
+      ...
+    TypeError: None is not a dataclass and cannot be turned into one.
     """
 
     try:
@@ -200,7 +205,7 @@ def class_schema(clazz: type) -> Type[marshmallow.Schema]:
         try:
             return class_schema(dataclasses.dataclass(clazz))
         except Exception:
-            raise TypeError(f"{clazz.__name__} is not a dataclass and cannot be turned into one.")
+            raise TypeError(f"{getattr(clazz, '__name__', repr(clazz))} is not a dataclass and cannot be turned into one.")
 
     # Copy all public members of the dataclass to the schema
     attributes = {k: v for k, v in inspect.getmembers(clazz) if not k.startswith('_')}


### PR DESCRIPTION
Before, the right exception was not thrown because formatting the error message caused an exception itself.