### PR TITLE
add support for enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ class Point:
     ordered = True
 ```
 
-## installation
+## Installation
 This package [is hosted on pypi](https://pypi.org/project/marshmallow-dataclass/) :
 
 ```shell

--- a/marshmallow_dataclass/__init__.py
+++ b/marshmallow_dataclass/__init__.py
@@ -289,8 +289,6 @@ def field_for_schema(
     if typ in _native_to_marshmallow:
         return _native_to_marshmallow[typ](**metadata)
 
-
-
     # Generic types
     origin: type = typing_inspect.get_origin(typ)
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-VERSION = '0.6.3'
+VERSION = '0.6.4'
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
     classifiers=CLASSIFIERS,
     install_requires=['marshmallow>=2.0,<3.0', 'typing-inspect'],
     extras_require={
+        'enum': ["marshmallow-enum<2.0"],
         ':python_version == "3.6"': ["dataclasses"],
         'dev': 'sphinx',
     },


### PR DESCRIPTION
`marshmallow_enum` is part of the marshmallow ecosystem. Accordingly, as a primary user of dataclasses, I would love `marshmallow_dataclass` to support enums. This PR adds that functionality as well as the requisite doctests.