### PR TITLE
Add support for union fields using marshmallow_union package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
   - "3.7-dev"
   - "3.8-dev"
 install:
-  - pipenv install --pre -e '.[enum,dev]'
+  - pipenv install --pre -e '.[union,enum,dev]'
 script:
   - pipenv run python -m doctest -v marshmallow_dataclass/*.py
   - cd docs && pipenv run make html && cd ..

--- a/marshmallow_dataclass/__init__.py
+++ b/marshmallow_dataclass/__init__.py
@@ -270,7 +270,6 @@ def field_for_schema(
     >>> field_for_schema(Enum("X", "a b c")).__class__
     <class 'marshmallow_enum.EnumField'>
 
-    >>> import marshmallow_union
     >>> import typing
     >>> field_for_schema(typing.Union[int,str]).__class__
     <class 'marshmallow_union.Union'>

--- a/marshmallow_dataclass/__init__.py
+++ b/marshmallow_dataclass/__init__.py
@@ -271,7 +271,8 @@ def field_for_schema(
     <class 'marshmallow_enum.EnumField'>
 
     >>> import marshmallow_union
-    >>> field_for_schema(Union[int,str]).__class__
+    >>> import typing
+    >>> field_for_schema(typing.Union[int,str]).__class__
     <class 'marshmallow_union.Union'>
 
     >>> field_for_schema(NewType('UserId', int)).__class__

--- a/marshmallow_dataclass/__init__.py
+++ b/marshmallow_dataclass/__init__.py
@@ -270,6 +270,9 @@ def field_for_schema(
     >>> field_for_schema(Enum("X", "a b c")).__class__
     <class 'marshmallow_enum.EnumField'>
 
+    >>> field_for_schema(Union[int,str]).__class__
+    <class 'marshmallow_union.Union'>
+
     >>> field_for_schema(NewType('UserId', int)).__class__
     <class 'marshmallow.fields.Integer'>
 
@@ -329,6 +332,12 @@ def field_for_schema(
             metadata['missing'] = metadata.get('missing', None)
             metadata['required'] = False
             return field_for_schema(subtyp, metadata=metadata)
+        elif typing_inspect.is_union_type(typ):
+            subfields = []
+            for subtyp in arguments:
+                subfields.append(field_for_schema(subtyp, metadata=metadata))
+            import marshmallow_union
+            return marshmallow_union.Union(subfields, **metadata)
 
     # typing.NewType returns a function with a __supertype__ attribute
     newtype_supertype = getattr(typ, '__supertype__', None)

--- a/marshmallow_dataclass/__init__.py
+++ b/marshmallow_dataclass/__init__.py
@@ -270,6 +270,7 @@ def field_for_schema(
     >>> field_for_schema(Enum("X", "a b c")).__class__
     <class 'marshmallow_enum.EnumField'>
 
+    >>> import marshmallow_union
     >>> field_for_schema(Union[int,str]).__class__
     <class 'marshmallow_union.Union'>
 
@@ -333,9 +334,7 @@ def field_for_schema(
             metadata['required'] = False
             return field_for_schema(subtyp, metadata=metadata)
         elif typing_inspect.is_union_type(typ):
-            subfields = []
-            for subtyp in arguments:
-                subfields.append(field_for_schema(subtyp, metadata=metadata))
+            subfields = [field_for_schema(subtyp, metadata=metadata) for subtyp in arguments]
             import marshmallow_union
             return marshmallow_union.Union(subfields, **metadata)
 

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
     install_requires=['marshmallow>=3.0.0rc4,<4.0', 'typing-inspect'],
     extras_require={
         'enum': ["marshmallow-enum"],
+        'union': ["marshmallow-union"],
         ':python_version == "3.6"': ["dataclasses"],
         'dev': 'sphinx',
     },


### PR DESCRIPTION
Fixes #24 

This is a proposal to add support for Union types.

It has been tested as follows:

EDIT: fixed tests to ACTUALLY test marshmallow serialization
```python
from marshmallow_dataclass import dataclass
from marshmallow import ValidationError
from typing import Union

@dataclass
class Test:
    union: Union[str, int]

t = Test('hello')
print(t.Schema._declared_fields['union'].__class__)  # <class 'marshmallow_union.Union'>
t2 = Test.Schema().load({'union': 'hello'})
t3 = Test.Schema().load({'union': 5})
try:
    t4 = Test.Schema().load({'union': False})
except ValidationError:
    pass
```

Thoughts?