### PR TITLE
Add pypy to the list of CI-tested versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "3.7.0"
   - "3.7"
   - "3.8-dev"
+  - "pypy3"
 install:
   - pipenv install --pre -e '.[dev]'
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,29 @@
 language: python
 dist: xenial
-python:
-  - "3.6"
-  - "3.7.0"
-  - "3.7"
-  - "3.8-dev"
-  - "pypy3"
+
+matrix:
+  include:
+    - python: "3.6"
+    - python: "3.7"
+    - python: "3.8"
+      env: RUN_PRE_COMMIT=1
+    - python: "pypy3"
+    - python: "nightly"
+
 install:
   - pipenv install --pre -e '.[dev]'
 script:
   - pipenv run python -m doctest -v marshmallow_dataclass/*.py
-  - pipenv run pre-commit run --all-files
+  - [ $ RUN_PRE_COMMIT ] && pipenv run pre-commit run --all-files
   - cd docs && pipenv run make html && cd ..
 stages:
   - test
   - deploy
 
 jobs:
+  allow_failure:
+    - python: nightly
+  fast_finish: true
   include:
     - stage: deploy
       python: 3.7


### PR DESCRIPTION
Do not merge yet !

Hey @sloria ! I noticed that your recent addition of `black` breaks CI if we want to test with pypy. All the other tests pass with pypy.

Black's incompatibility with pypy is known both by pypy and black:
 - https://bitbucket.org/pypy/pypy/issues/2985/pypy36-osreplace-pathlike-typeerror
 - https://github.com/psf/black/issues/780

I feel like the advantages of testing with pypy are larger than those of using black.
What do you think about using a different formatter ?
We could also disable formatting tests with pypy, but since we just started adding formatting to CI, I feel it's still easy to change.