### PR TITLE
Filter out non required members from schema attributes

### DIFF
--- a/marshmallow_dataclass/__init__.py
+++ b/marshmallow_dataclass/__init__.py
@@ -273,8 +273,9 @@ def class_schema(
                 f"{getattr(clazz, '__name__', repr(clazz))} is not a dataclass and cannot be turned into one."
             )
 
-    # Copy all whitelisted members of the dataclass to the schema.
-    attributes = {k: v for k, v in inspect.getmembers(clazz) if k in MEMBERS_WHITELIST}
+    # Copy all marshmallow hooks and whitelisted members of the dataclass to the schema.
+    attributes = {k: v for k, v in inspect.getmembers(clazz)
+                  if hasattr(v, '__marshmallow_hook__') or k in MEMBERS_WHITELIST}
     # Update the schema members to contain marshmallow fields instead of dataclass fields
     attributes.update(
         (

--- a/marshmallow_dataclass/__init__.py
+++ b/marshmallow_dataclass/__init__.py
@@ -61,7 +61,7 @@ __all__ = ["dataclass", "add_schema", "class_schema", "field_for_schema", "NewTy
 NoneType = type(None)
 _U = TypeVar("_U")
 
-# Whitlist of dataclass members that will be copyied to generated schema.
+# Whitelist of dataclass members that will be copied to generated schema.
 MEMBERS_WHITELIST: Set[str] = {"Meta"}
 
 
@@ -271,41 +271,21 @@ def class_schema(
     ...     @marshmallow.validates_schema
     ...     def validates_schema(self, *args, **kwargs):
     ...         pass
-    ...     @marshmallow.pre_dump
-    ...     def pre_dump(self, *args, **kwargs):
-    ...         pass
-    ...     @marshmallow.post_dump
-    ...     def post_dump(self, *args, **kwargs):
-    ...         pass
-    ...     @marshmallow.pre_load
-    ...     def pre_load(self, *args, **kwargs):
-    ...         pass
-    ...     @marshmallow.post_load
-    ...     def post_load(self, *args, **kwargs):
-    ...         pass
     ...     def custom_method(self, *args, **kwargs):
     ...         pass
     ...     @property
     ...     def custom_property(self, *args, **kwargs):
     ...         return None
-
-    >>> hasattr(class_schema(Anything), 'Meta')
+    >>> AnythingSchema = class_schema(Anything)()
+    >>> hasattr(AnythingSchema, 'Meta')
     True
-    >>> hasattr(class_schema(Anything), 'validates')
+    >>> hasattr(AnythingSchema, 'validates')
     True
-    >>> hasattr(class_schema(Anything), 'validates_schema')
+    >>> hasattr(AnythingSchema, 'validates_schema')
     True
-    >>> hasattr(class_schema(Anything), 'pre_dump')
-    True
-    >>> hasattr(class_schema(Anything), 'post_dump')
-    True
-    >>> hasattr(class_schema(Anything), 'pre_load')
-    True
-    >>> hasattr(class_schema(Anything), 'post_load')
-    True
-    >>> hasattr(class_schema(Anything), 'custom_method')
+    >>> hasattr(AnythingSchema, 'custom_method')
     False
-    >>> hasattr(class_schema(Anything), 'custom_property')
+    >>> hasattr(AnythingSchema, 'custom_property')
     False
     """
 

--- a/marshmallow_dataclass/__init__.py
+++ b/marshmallow_dataclass/__init__.py
@@ -62,7 +62,7 @@ NoneType = type(None)
 _U = TypeVar("_U")
 
 # Whitlist of dataclass members that will be copyied to generated schema.
-MEMBERS_WHITELIST: Set[str]  = {'Meta',}
+MEMBERS_WHITELIST: Set[str] = {'Meta'}
 
 
 # _cls should never be specified by keyword, so start it with an
@@ -321,8 +321,11 @@ def class_schema(
             )
 
     # Copy all marshmallow hooks and whitelisted members of the dataclass to the schema.
-    attributes = {k: v for k, v in inspect.getmembers(clazz)
-                  if hasattr(v, '__marshmallow_hook__') or k in MEMBERS_WHITELIST}
+    attributes = {
+        k: v
+        for k, v in inspect.getmembers(clazz)
+        if hasattr(v, "__marshmallow_hook__") or k in MEMBERS_WHITELIST
+    }
     # Update the schema members to contain marshmallow fields instead of dataclass fields
     attributes.update(
         (

--- a/marshmallow_dataclass/__init__.py
+++ b/marshmallow_dataclass/__init__.py
@@ -50,6 +50,7 @@ from typing import (
     TypeVar,
     Union,
     Callable,
+    Set,
 )
 
 import marshmallow
@@ -59,6 +60,9 @@ __all__ = ["dataclass", "add_schema", "class_schema", "field_for_schema", "NewTy
 
 NoneType = type(None)
 _U = TypeVar("_U")
+
+# Whitlist of dataclass members that will be copyied to generated schema.
+MEMBERS_WHITELIST: Set[str]  = {'Meta',}
 
 
 # _cls should never be specified by keyword, so start it with an
@@ -269,8 +273,8 @@ def class_schema(
                 f"{getattr(clazz, '__name__', repr(clazz))} is not a dataclass and cannot be turned into one."
             )
 
-    # Copy all public members of the dataclass to the schema
-    attributes = {k: v for k, v in inspect.getmembers(clazz) if not k.startswith("_")}
+    # Copy all whitelisted members of the dataclass to the schema.
+    attributes = {k: v for k, v in inspect.getmembers(clazz) if k in MEMBERS_WHITELIST}
     # Update the schema members to contain marshmallow fields instead of dataclass fields
     attributes.update(
         (

--- a/marshmallow_dataclass/__init__.py
+++ b/marshmallow_dataclass/__init__.py
@@ -260,6 +260,53 @@ def class_schema(
     Traceback (most recent call last):
       ...
     TypeError: None is not a dataclass and cannot be turned into one.
+
+    >>> @dataclasses.dataclass
+    ... class Anything:
+    ...     class Meta:
+    ...         pass
+    ...     @marshmallow.validates('name')
+    ...     def validates(self, *args, **kwargs):
+    ...         pass
+    ...     @marshmallow.validates_schema
+    ...     def validates_schema(self, *args, **kwargs):
+    ...         pass
+    ...     @marshmallow.pre_dump
+    ...     def pre_dump(self, *args, **kwargs):
+    ...         pass
+    ...     @marshmallow.post_dump
+    ...     def post_dump(self, *args, **kwargs):
+    ...         pass
+    ...     @marshmallow.pre_load
+    ...     def pre_load(self, *args, **kwargs):
+    ...         pass
+    ...     @marshmallow.post_load
+    ...     def post_load(self, *args, **kwargs):
+    ...         pass
+    ...     def custom_method(self, *args, **kwargs):
+    ...         pass
+    ...     @property
+    ...     def custom_property(self, *args, **kwargs):
+    ...         return None
+
+    >>> hasattr(class_schema(Anything), 'Meta')
+    True
+    >>> hasattr(class_schema(Anything), 'validates')
+    True
+    >>> hasattr(class_schema(Anything), 'validates_schema')
+    True
+    >>> hasattr(class_schema(Anything), 'pre_dump')
+    True
+    >>> hasattr(class_schema(Anything), 'post_dump')
+    True
+    >>> hasattr(class_schema(Anything), 'pre_load')
+    True
+    >>> hasattr(class_schema(Anything), 'post_load')
+    True
+    >>> hasattr(class_schema(Anything), 'custom_method')
+    False
+    >>> hasattr(class_schema(Anything), 'custom_property')
+    False
     """
 
     try:

--- a/marshmallow_dataclass/__init__.py
+++ b/marshmallow_dataclass/__init__.py
@@ -62,7 +62,7 @@ NoneType = type(None)
 _U = TypeVar("_U")
 
 # Whitlist of dataclass members that will be copyied to generated schema.
-MEMBERS_WHITELIST: Set[str] = {'Meta'}
+MEMBERS_WHITELIST: Set[str] = {"Meta"}
 
 
 # _cls should never be specified by keyword, so start it with an


### PR DESCRIPTION
#47 

Allowing just whitelisted members was not enough, so I had to add one more filter 
 to allow marshmallow hooks to be declared and copied to schema. I also added tests to check if those filters are applied.