### PR TITLE
Include LICENSE file in the sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE


### PR DESCRIPTION
This change adds the LICENSE file to the sdist uploaded to pypi.org. This will aid analysis tools like JFrog Xray in determining how this project is licensed.