### PR TITLE
switch 'type is' to 'isinstance' for enum check

### DIFF
--- a/marshmallow_dataclass/__init__.py
+++ b/marshmallow_dataclass/__init__.py
@@ -417,7 +417,7 @@ def field_for_schema(
             )
 
     # enumerations
-    if type(typ) is EnumMeta:
+    if isinstance(typ, EnumMeta):
         import marshmallow_enum
 
         return marshmallow_enum.EnumField(typ, **metadata)


### PR DESCRIPTION
When using an Enum that has extended the EnumMeta (Djangos 'TextChoices' is a concrete example), the 'type(typ) is EnumMeta' fails the "Enum type check". Changing this to 'isinstance(typ, EnumMeta)' will pass the "Enum type check" also for these enums with an extended EnumMeta.