### PR TITLE
Add basic cache support

### DIFF
--- a/marshmallow_dataclass/__init__.py
+++ b/marshmallow_dataclass/__init__.py
@@ -68,6 +68,7 @@ MEMBERS_WHITELIST: Set[str] = {"Meta"}
 # Max number of generated schemas that class_schema keeps of generated schemas. Removes duplicates.
 MAX_CLASS_SCHEMA_CACHE_SIZE = 1024
 
+
 # _cls should never be specified by keyword, so start it with an
 # underscore.  The presence of _cls is used to detect if this
 # decorator is being called with parameters or not.

--- a/marshmallow_dataclass/__init__.py
+++ b/marshmallow_dataclass/__init__.py
@@ -313,8 +313,7 @@ def _proxied_class_schema(
     )
 
     schema_class = type(clazz.__name__, (_base_schema(clazz, base_schema),), attributes)
-    result = cast(Type[marshmallow.Schema], schema_class)
-    return result
+    return cast(Type[marshmallow.Schema], schema_class)
 
 
 _native_to_marshmallow: Dict[Union[type, Any], Type[marshmallow.fields.Field]] = {

--- a/marshmallow_dataclass/__init__.py
+++ b/marshmallow_dataclass/__init__.py
@@ -191,7 +191,6 @@ def class_schema(
     ...
     >>> class_schema(Building) # Returns a marshmallow schema class (not an instance)
     <class 'marshmallow.schema.Building'>
-
     >>> @dataclasses.dataclass()
     ... class City:
     ...   name: str = dataclasses.field(metadata={'required':True})
@@ -274,28 +273,6 @@ def class_schema(
     Traceback (most recent call last):
     ...
     marshmallow.exceptions.ValidationError: {'name': ['Name too long']}
-    >>> @dataclasses.dataclass
-    ... class Simple:
-    ...     one: str = dataclasses.field()
-    ...     two: str = dataclasses.field()
-    >>> @dataclasses.dataclass
-    ... class ComplexNested:
-    ...     three: int = dataclasses.field()
-    ...     four: Simple = dataclasses.field()
-    >>> id(class_schema(ComplexNested)) == id(class_schema(ComplexNested))
-    True
-    >>> class_schema(ComplexNested) is class_schema(ComplexNested)
-    True
-    >>> id(class_schema(Simple)) == id(class_schema(Simple))
-    True
-    >>> class_schema(Simple) is class_schema(Simple)
-    True
-    >>> class_schema(Simple) is class_schema(ComplexNested)._declared_fields["four"].nested
-    True
-    >>> len(set([class_schema(ComplexNested), class_schema(ComplexNested, base_schema=None), class_schema(ComplexNested, None)]))
-    1
-    >>> len(set([class_schema(Simple), class_schema(Simple, base_schema=None), class_schema(Simple, None)]))
-    1
     """
     cached_schema = SCHEMA_REGISTRY.get((clazz, base_schema), None)
     if cached_schema is not None:

--- a/tests/test_class_schema.py
+++ b/tests/test_class_schema.py
@@ -16,15 +16,11 @@ class TestClassSchema(unittest.TestCase):
             three: int = dataclasses.field()
             four: Simple = dataclasses.field()
 
-        self.assertEqual(
-            id(class_schema(ComplexNested)), id(class_schema(ComplexNested))
-        )
-        self.assertTrue(class_schema(ComplexNested) is class_schema(ComplexNested))
-        self.assertEqual(id(class_schema(Simple)), id(class_schema(Simple)))
-        self.assertTrue(class_schema(Simple) is class_schema(Simple))
-        self.assertTrue(
-            class_schema(Simple)
-            is class_schema(ComplexNested)._declared_fields["four"].nested
+        self.assertIs(class_schema(ComplexNested), class_schema(ComplexNested))
+        self.assertIs(class_schema(Simple), class_schema(Simple))
+        self.assertIs(
+            class_schema(Simple),
+            class_schema(ComplexNested)._declared_fields["four"].nested,
         )
 
         complex_set = {

--- a/tests/test_class_schema.py
+++ b/tests/test_class_schema.py
@@ -5,7 +5,6 @@ from marshmallow_dataclass import class_schema
 
 
 class TestClassSchema(unittest.TestCase):
-
     def test_simple_unique_schemas(self):
         @dataclasses.dataclass
         class Simple:
@@ -17,15 +16,27 @@ class TestClassSchema(unittest.TestCase):
             three: int = dataclasses.field()
             four: Simple = dataclasses.field()
 
-        self.assertEqual(id(class_schema(ComplexNested)), id(class_schema(ComplexNested)))
+        self.assertEqual(
+            id(class_schema(ComplexNested)), id(class_schema(ComplexNested))
+        )
         self.assertTrue(class_schema(ComplexNested) is class_schema(ComplexNested))
         self.assertEqual(id(class_schema(Simple)), id(class_schema(Simple)))
         self.assertTrue(class_schema(Simple) is class_schema(Simple))
-        self.assertTrue(class_schema(Simple) is class_schema(ComplexNested)._declared_fields["four"].nested)
+        self.assertTrue(
+            class_schema(Simple)
+            is class_schema(ComplexNested)._declared_fields["four"].nested
+        )
 
-        complex_set = {class_schema(ComplexNested), class_schema(ComplexNested, base_schema=None),
-                       class_schema(ComplexNested, None)}
-        simple_set = {class_schema(Simple), class_schema(Simple, base_schema=None), class_schema(Simple, None)}
+        complex_set = {
+            class_schema(ComplexNested),
+            class_schema(ComplexNested, base_schema=None),
+            class_schema(ComplexNested, None),
+        }
+        simple_set = {
+            class_schema(Simple),
+            class_schema(Simple, base_schema=None),
+            class_schema(Simple, None),
+        }
         self.assertEqual(len(complex_set), 1)
         self.assertEqual(len(simple_set), 1)
 

--- a/tests/test_class_schema.py
+++ b/tests/test_class_schema.py
@@ -1,0 +1,34 @@
+import dataclasses
+import unittest
+
+from marshmallow_dataclass import class_schema
+
+
+class TestClassSchema(unittest.TestCase):
+
+    def test_simple_unique_schemas(self):
+        @dataclasses.dataclass
+        class Simple:
+            one: str = dataclasses.field()
+            two: str = dataclasses.field()
+
+        @dataclasses.dataclass
+        class ComplexNested:
+            three: int = dataclasses.field()
+            four: Simple = dataclasses.field()
+
+        self.assertEqual(id(class_schema(ComplexNested)), id(class_schema(ComplexNested)))
+        self.assertTrue(class_schema(ComplexNested) is class_schema(ComplexNested))
+        self.assertEqual(id(class_schema(Simple)), id(class_schema(Simple)))
+        self.assertTrue(class_schema(Simple) is class_schema(Simple))
+        self.assertTrue(class_schema(Simple) is class_schema(ComplexNested)._declared_fields["four"].nested)
+
+        complex_set = {class_schema(ComplexNested), class_schema(ComplexNested, base_schema=None),
+                       class_schema(ComplexNested, None)}
+        simple_set = {class_schema(Simple), class_schema(Simple, base_schema=None), class_schema(Simple, None)}
+        self.assertEqual(len(complex_set), 1)
+        self.assertEqual(len(simple_set), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
When dynamically creating marshmallow schemas and registering them with marshmallow registry (for ApiSpec using the marshmallow plugin). This is an attempt at returning the same "schema" instance when the same input type is used to generate it.

Otherwise, marshmallow sees them as completely unique schemas despite having the same name + fields.