### PR TITLE
Allow to map a custom Field class to a Type

### DIFF
--- a/marshmallow_dataclass/__init__.py
+++ b/marshmallow_dataclass/__init__.py
@@ -81,12 +81,14 @@ def dataclass(
     unsafe_hash: bool = False,
     frozen: bool = False,
     base_schema: Optional[Type[marshmallow.Schema]] = None,
+    generic_types: Optional[Dict[Type, Type[marshmallow.Schema]]] = None,
 ) -> Union[Type[_U], Callable[[Type[_U]], Type[_U]]]:
     """
     This decorator does the same as dataclasses.dataclass, but also applies :func:`add_schema`.
     It adds a `.Schema` attribute to the class object
 
     :param base_schema: marshmallow schema used as a base class when deriving dataclass schema
+    :param generic_types: dict to map generic type to custom marshmallow schema
 
     >>> @dataclass
     ... class Artist:
@@ -110,8 +112,8 @@ def dataclass(
         _cls, repr=repr, eq=eq, order=order, unsafe_hash=unsafe_hash, frozen=frozen
     )
     if _cls is None:
-        return lambda cls: add_schema(dc(cls), base_schema)
-    return add_schema(dc, base_schema)
+        return lambda cls: add_schema(dc(cls), base_schema, generic_types)
+    return add_schema(dc, base_schema, generic_types)
 
 
 @overload
@@ -122,24 +124,27 @@ def add_schema(_cls: Type[_U]) -> Type[_U]:
 @overload
 def add_schema(
     base_schema: Type[marshmallow.Schema] = None,
+    generic_types: Optional[Dict[Type, Type[marshmallow.Schema]]] = None,
 ) -> Callable[[Type[_U]], Type[_U]]:
     ...
 
 
 @overload
 def add_schema(
-    _cls: Type[_U], base_schema: Type[marshmallow.Schema] = None
+    _cls: Type[_U], base_schema: Type[marshmallow.Schema] = None,
+    generic_types: Optional[Dict[Type, Type[marshmallow.Schema]]] = None,
 ) -> Type[_U]:
     ...
 
 
-def add_schema(_cls=None, base_schema=None):
+def add_schema(_cls=None, base_schema=None, generic_types=None):
     """
     This decorator adds a marshmallow schema as the 'Schema' attribute in a dataclass.
     It uses :func:`class_schema` internally.
 
     :param type cls: The dataclass to which a Schema should be added
     :param base_schema: marshmallow schema used as a base class when deriving dataclass schema
+    :param generic_types: dict to map generic type to custom marshmallow schema
 
     >>> class BaseSchema(marshmallow.Schema):
     ...   def on_bind_field(self, field_name, field_obj):
@@ -155,14 +160,15 @@ def add_schema(_cls=None, base_schema=None):
     """
 
     def decorator(clazz: Type[_U]) -> Type[_U]:
-        clazz.Schema = class_schema(clazz, base_schema)  # type: ignore
+        clazz.Schema = class_schema(clazz, base_schema, generic_types)  # type: ignore
         return clazz
 
     return decorator(_cls) if _cls else decorator
 
 
 def class_schema(
-    clazz: type, base_schema: Optional[Type[marshmallow.Schema]] = None
+    clazz: type, base_schema: Optional[Type[marshmallow.Schema]] = None,
+    generic_types: Optional[Dict[Type, Type[marshmallow.Schema]]] = None,
 ) -> Type[marshmallow.Schema]:
 
     """
@@ -170,6 +176,7 @@ def class_schema(
 
     :param clazz: A python class (may be a dataclass)
     :param base_schema: marshmallow schema used as a base class when deriving dataclass schema
+    :param generic_types: dict to map generic type to custom marshmallow schema
     :return: A marshmallow Schema corresponding to the dataclass
 
     .. note::
@@ -275,12 +282,15 @@ def class_schema(
     ...
     marshmallow.exceptions.ValidationError: {'name': ['Name too long']}
     """
-    return _proxied_class_schema(clazz, base_schema)
+    # convert to hashable type (tuple) for lru_cache
+    generic_types = tuple(generic_types.items()) if generic_types else ()
+    return _proxied_class_schema(clazz, base_schema, generic_types)
 
 
 @lru_cache(maxsize=MAX_CLASS_SCHEMA_CACHE_SIZE)
 def _proxied_class_schema(
-    clazz: type, base_schema: Optional[Type[marshmallow.Schema]] = None
+    clazz: type, base_schema: Optional[Type[marshmallow.Schema]] = None,
+    generic_types: Tuple[Tuple[Dict[Type, Type[marshmallow.Schema]]]] = None,
 ) -> Type[marshmallow.Schema]:
 
     try:
@@ -288,7 +298,9 @@ def _proxied_class_schema(
         fields: Tuple[dataclasses.Field, ...] = dataclasses.fields(clazz)
     except TypeError:  # Not a dataclass
         try:
-            return class_schema(dataclasses.dataclass(clazz), base_schema)
+            return class_schema(
+                dataclasses.dataclass(clazz), base_schema, dict(generic_types)
+            )
         except Exception:
             raise TypeError(
                 f"{getattr(clazz, '__name__', repr(clazz))} is not a dataclass and cannot be turned into one."
@@ -305,7 +317,11 @@ def _proxied_class_schema(
         (
             field.name,
             field_for_schema(
-                field.type, _get_field_default(field), field.metadata, base_schema
+                field.type,
+                _get_field_default(field),
+                field.metadata,
+                base_schema,
+                dict(generic_types),
             ),
         )
         for field in fields
@@ -332,6 +348,7 @@ def field_for_schema(
     default=marshmallow.missing,
     metadata: Mapping[str, Any] = None,
     base_schema: Optional[Type[marshmallow.Schema]] = None,
+    generic_types: Optional[Dict[Type, Type[marshmallow.Schema]]] = None,
 ) -> marshmallow.fields.Field:
     """
     Get a marshmallow Field corresponding to the given python type.
@@ -341,6 +358,7 @@ def field_for_schema(
     :param default: value to use for (de)serialization when the field is missing
     :param metadata: Additional parameters to pass to the marshmallow field constructor
     :param base_schema: marshmallow schema used as a base class when deriving dataclass schema
+    :param generic_types: dict to map generic type to custom marshmallow schema
 
     >>> int_field = field_for_schema(int, default=9, metadata=dict(required=True))
     >>> int_field.__class__
@@ -354,6 +372,8 @@ def field_for_schema(
     """
 
     metadata = {} if metadata is None else dict(metadata)
+    generic_types = dict(generic_types) if generic_types else {}
+
     if default is not marshmallow.missing:
         metadata.setdefault("default", default)
         # 'missing' must not be set for required fields.
@@ -383,17 +403,27 @@ def field_for_schema(
     if origin:
         arguments = typing_inspect.get_args(typ, True)
         if origin in (list, List):
-            child_type = field_for_schema(arguments[0], base_schema=base_schema)
-            return marshmallow.fields.List(child_type, **metadata)
+            child_type = field_for_schema(
+                arguments[0], base_schema=base_schema, generic_types=generic_types
+            )
+            list_type = generic_types.get(List, marshmallow.fields.List)
+            return list_type(child_type, **metadata)
         if origin in (tuple, Tuple):
             children = tuple(
-                field_for_schema(arg, base_schema=base_schema) for arg in arguments
+                field_for_schema(
+                    arg, base_schema=base_schema, generic_types=generic_types
+                ) for arg in arguments
             )
             return marshmallow.fields.Tuple(children, **metadata)
         elif origin in (dict, Dict):
-            return marshmallow.fields.Dict(
-                keys=field_for_schema(arguments[0], base_schema=base_schema),
-                values=field_for_schema(arguments[1], base_schema=base_schema),
+            dict_type = generic_types.get(Dict, marshmallow.fields.Dict)
+            return dict_type(
+                keys=field_for_schema(
+                    arguments[0], base_schema=base_schema, generic_types=generic_types,
+                ),
+                values=field_for_schema(
+                    arguments[1], base_schema=base_schema, generic_types=generic_types,
+                ),
                 **metadata,
             )
         elif typing_inspect.is_optional_type(typ):
@@ -402,7 +432,12 @@ def field_for_schema(
             metadata["default"] = metadata.get("default", None)
             metadata["missing"] = metadata.get("missing", None)
             metadata["required"] = False
-            return field_for_schema(subtyp, metadata=metadata, base_schema=base_schema)
+            return field_for_schema(
+                subtyp,
+                metadata=metadata,
+                base_schema=base_schema,
+                generic_types=generic_types,
+            )
         elif typing_inspect.is_union_type(typ):
             subfields = [
                 field_for_schema(subtyp, metadata=metadata, base_schema=base_schema)
@@ -430,6 +465,7 @@ def field_for_schema(
                 metadata=metadata,
                 default=default,
                 base_schema=base_schema,
+                generic_types=generic_types,
             )
 
     # enumerations
@@ -444,7 +480,9 @@ def field_for_schema(
     # Nested dataclasses
     forward_reference = getattr(typ, "__forward_arg__", None)
     nested = (
-        nested_schema or forward_reference or class_schema(typ, base_schema=base_schema)
+        nested_schema
+        or forward_reference
+        or class_schema(typ, base_schema=base_schema, generic_types=generic_types)
     )
 
     return marshmallow.fields.Nested(nested, **metadata)

--- a/tests/test_field_for_schema.py
+++ b/tests/test_field_for_schema.py
@@ -2,7 +2,7 @@ import inspect
 import typing
 import unittest
 from enum import Enum
-from typing import Dict, Optional, Union, Any
+from typing import Dict, Optional, Union, Any, List
 
 from marshmallow import fields, Schema
 
@@ -113,6 +113,21 @@ class TestFieldForSchema(unittest.TestCase):
         self.assertFieldsEqual(
             field_for_schema(NewDataclass, metadata=dict(required=False)),
             fields.Nested(NewDataclass.Schema),
+        )
+
+    def test_force_generic_types(self):
+        from marshmallow.fields import List as BaseList
+
+        class MyList(BaseList):
+            ...
+
+        self.assertIsInstance(
+            field_for_schema(List[int]), BaseList
+        )
+
+        self.assertIsInstance(
+            field_for_schema(List[int], generic_types={List: MyList}),
+            MyList
         )
 
 


### PR DESCRIPTION
This patch allow us to map a custom implementation of a field to map to a
generic type.
eg:

```
def dataclass(*args, **kwargs):
    kwargs["generic_types"] = kwargs.get("generic_types", {typing.List: MyList})
    return marshmallow_dataclass.dataclass(*args, **kwargs)

@dataclass
class MyClass:
  foo: List[int]
```

Foo will be a `MyList` field and not a `marshmallow.fields.List`

Credits goes to @ybadiss to have developed this patch