### PR TITLE
Remove return function annotation from dataclass().

### DIFF
--- a/marshmallow_dataclass/__init__.py
+++ b/marshmallow_dataclass/__init__.py
@@ -81,7 +81,7 @@ def dataclass(
     unsafe_hash: bool = False,
     frozen: bool = False,
     base_schema: Optional[Type[marshmallow.Schema]] = None,
-) -> Union[Type[_U], Callable[[Type[_U]], Type[_U]]]:
+):
     """
     This decorator does the same as dataclasses.dataclass, but also applies :func:`add_schema`.
     It adds a `.Schema` attribute to the class object
@@ -164,7 +164,6 @@ def add_schema(_cls=None, base_schema=None):
 def class_schema(
     clazz: type, base_schema: Optional[Type[marshmallow.Schema]] = None
 ) -> Type[marshmallow.Schema]:
-
     """
     Convert a class to a marshmallow schema
 

--- a/tests/test_mypy.yml
+++ b/tests/test_mypy.yml
@@ -37,3 +37,14 @@
         name: str
 
     user = User(id=4, name='Johny')
+- case: marshmallow_dataclass_type_inference
+  mypy_config: |
+    follow_imports = silent
+    plugins = marshmallow_dataclass.mypy
+  main: |
+    from marshmallow_dataclass import dataclass
+
+    @dataclass(frozen=True)
+    class User:
+        id: int
+        name: str


### PR DESCRIPTION
Match marshmallow_dataclass/init.py dataclass() with dataclasses.py dataclass().
Set frozen=True as a use-case. Running with return function annotation results in: Cannot instantiate type "Type[]" error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lovasoa/marshmallow_dataclass/98)
<!-- Reviewable:end -->
