### PR TITLE
add conda recipe

### DIFF
--- a/conda_recipe/bld.bat
+++ b/conda_recipe/bld.bat
@@ -1,0 +1,2 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1

--- a/conda_recipe/build.sh
+++ b/conda_recipe/build.sh
@@ -1,0 +1,1 @@
+python setup.py install

--- a/conda_recipe/meta.yaml
+++ b/conda_recipe/meta.yaml
@@ -1,0 +1,50 @@
+{% set pypi_name = "marshmallow_dataclass" %}
+{% set conda_name = "marshmallow-dataclass" %}
+{% set version = "8.0.0" %}
+
+package:
+  name: "{{ conda_name }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.io/packages/source/{{ pypi_name[0] }}/{{ pypi_name }}/{{ pypi_name }}-{{ version }}.tar.gz"
+  sha256: "cde644b272c2284f1212f0e0d25bdb9eaf7d58f1423ae82b712ba43db229d618"
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "
+
+requirements:
+  host:
+    - dataclasses
+    - marshmallow >=3.0.0,<4.0
+    - marshmallow-enum
+    - pip
+    - python
+    - typeguard
+    - typing_inspect
+  run:
+    - dataclasses
+    - marshmallow >=3.0.0,<4.0
+    - marshmallow-enum
+    - python >=3.6
+    - typeguard
+    - typing_inspect
+
+test:
+  imports:
+    - marshmallow_dataclass
+
+about:
+  home: "https://github.com/lovasoa/marshmallow_dataclass"
+  license: MIT Expat License
+  license_family: MIT
+  license_file: LICENSE
+  summary: "Python library to convert dataclasses into marshmallow schemas."
+  doc_url: "https://lovasoa.github.io/marshmallow_dataclass/html/index.html"
+  dev_url: "https://github.com/lovasoa/marshmallow_dataclass"
+
+extra:
+  recipe-maintainers:
+    - lovasoa
+    - ElenaBossolini


### PR DESCRIPTION
Adding conda recipe for marshmallow_dataclass with both extras (enum, union),  but excluding extra packages for docs, lints and tests. 

I have set a `conda_name` and a `pypi_name` because naming convention of conda packages is with hyphens rather than with underscores.  

I have created the package and run the installation on an ad-hoc environment from my local channel and it worked fine. But I think it would be good if you can repeat the procedure. 
1) to build the package:
run `conda build conda_recipe -c defaults -c conda-forge`  from the `marshmallow_dataclass` parent repository
2) refresh the index in your local channel by typing `conda index`
3) create and ah-hoc env such as `conda create -n marshmallow_dc_test`
4) install the package by running `conda install -n marshmallow_dc_test marshmallow**-**dataclass -c <your_local_channel> -c defaults -c conda-forge` 
This should do the game. You can check by typing  `conda list` whether the extra packages have been included as well. 