### PR TITLE
fix serialization for Optional type

### DIFF
--- a/marshmallow_dataclass/union_field.py
+++ b/marshmallow_dataclass/union_field.py
@@ -36,6 +36,8 @@ class Union(fields.Field):
 
     def _serialize(self, value: Any, attr: str, obj, **kwargs) -> Any:
         errors = []
+        if value is None and not self.required:
+            return value
         for typ, field in self.union_fields:
             try:
                 typeguard.check_type(attr, value, typ)

--- a/tests/test_union.py
+++ b/tests/test_union.py
@@ -1,5 +1,5 @@
 import unittest
-from typing import List, Union, Dict
+from typing import List, Optional, Union, Dict
 
 import marshmallow
 
@@ -133,3 +133,24 @@ class TestClassSchema(unittest.TestCase):
         data_in = {"value": [1.4, 4.2]}
         with self.assertRaises(marshmallow.exceptions.ValidationError):
             self.assertEqual(schema.dump(schema.load(data_in)), data_in)
+
+    def test_union_optional_object(self):
+        @dataclass
+        class Elm1:
+            elm1: str
+
+        @dataclass
+        class Elm2:
+            elm2: str
+
+        @dataclass
+        class Dclass:
+            value: Optional[Union[Elm1, Elm2]]
+
+        schema = Dclass.Schema()
+
+        for data_in in [{"value": {"elm1": "hello"}}, {"value": {"elm2": "hello"}}]:
+            self.assertEqual(schema.dump(schema.load(data_in)), data_in)
+
+        for data_in in [{"value": None}, {}]:
+            self.assertEqual(schema.dump(schema.load(data_in)), {"value": None})


### PR DESCRIPTION
After https://github.com/lovasoa/marshmallow_dataclass/pull/100, the
serialization works correctly, however the deserialization can fail.

eg
```
class Dclass:
  value: Optional[Union[int, str]]
```

If we load `{"value": None}` we correctly have `Dclass(value=None)`, but
serializing back this value will give an error

```
TypeError: Unable to serialize value with any of the fields in the union:
[TypeError('type of value must be int; got NoneType instead'), TypeError('type
of value must be str; got NoneType instead')]
```

The idea of this patch is to accept None when required=False