### PR TITLE
Add support for Literal type

### DIFF
--- a/marshmallow_dataclass/__init__.py
+++ b/marshmallow_dataclass/__init__.py
@@ -451,6 +451,17 @@ def field_for_schema(
         metadata.setdefault("allow_none", True)
         return marshmallow.fields.Raw(**metadata)
 
+    if typing_inspect.is_literal_type(typ):
+        arguments = typing_inspect.get_args(typ)
+        return marshmallow.fields.Raw(
+            validate=(
+                marshmallow.validate.Equal(arguments[0])
+                if len(arguments) == 1
+                else marshmallow.validate.OneOf(arguments)
+            ),
+            **metadata,
+        )
+
     # Generic types
     origin = typing_inspect.get_origin(typ)
     if origin:

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,10 @@ EXTRAS_REQUIRE = {
         # re: pypy: typed-ast (a dependency of mypy) fails to install on pypy
         # https://github.com/python/typed_ast/issues/111
         "pytest-mypy-plugins>=1.2.0; implementation_name != 'pypy'",
+        # `Literal` was introduced in:
+        # - Python 3.8 (https://www.python.org/dev/peps/pep-0586)
+        # - typing-extensions 3.7.2 (https://github.com/python/typing/pull/591)
+        "typing-extensions~=3.7.2; python_version < '3.8'",
     ],
 }
 EXTRAS_REQUIRE["dev"] = (

--- a/tests/test_class_schema.py
+++ b/tests/test_class_schema.py
@@ -146,9 +146,8 @@ class TestClassSchema(unittest.TestCase):
         self.assertEqual(A(data="a"), schema.load({"data": "a"}))
         self.assertEqual(schema.dump(A(data="a")), {"data": "a"})
         for data in ["b", 2, 2.34, False]:
-            self.assertRaises(
-                ValidationError, lambda data=data: schema.load({"data": data})
-            )
+            with self.assertRaises(ValidationError):
+                schema.load({"data": data})
 
     def test_literal_multiple_types(self):
         @dataclasses.dataclass
@@ -160,9 +159,8 @@ class TestClassSchema(unittest.TestCase):
             self.assertEqual(A(data=data), schema.load({"data": data}))
             self.assertEqual(schema.dump(A(data=data)), {"data": data})
         for data in ["b", 2, 2.34, False]:
-            self.assertRaises(
-                ValidationError, lambda data=data: schema.load({"data": data})
-            )
+            with self.assertRaises(ValidationError):
+                schema.load({"data": data})
 
     def test_validator_stacking(self):
         # See: https://github.com/lovasoa/marshmallow_dataclass/issues/91

--- a/tests/test_class_schema.py
+++ b/tests/test_class_schema.py
@@ -3,6 +3,11 @@ import unittest
 from typing import Any
 from uuid import UUID
 
+try:
+    from typing import Literal  # type: ignore
+except ImportError:
+    from typing_extensions import Literal
+
 import dataclasses
 from marshmallow import Schema, ValidationError
 from marshmallow.fields import Field, UUID as UUIDField, List as ListField, Integer
@@ -131,6 +136,33 @@ class TestClassSchema(unittest.TestCase):
 
         schema = class_schema(A)()
         self.assertRaises(ValidationError, lambda: schema.load({"data": None}))
+
+    def test_literal(self):
+        @dataclasses.dataclass
+        class A:
+            data: Literal["a"]
+
+        schema = class_schema(A)()
+        self.assertEqual(A(data="a"), schema.load({"data": "a"}))
+        self.assertEqual(schema.dump(A(data="a")), {"data": "a"})
+        for data in ["b", 2, 2.34, False]:
+            self.assertRaises(
+                ValidationError, lambda data=data: schema.load({"data": data})
+            )
+
+    def test_literal_multiple_types(self):
+        @dataclasses.dataclass
+        class A:
+            data: Literal["a", 1, 1.23, True]
+
+        schema = class_schema(A)()
+        for data in ["a", 1, 1.23, True]:
+            self.assertEqual(A(data=data), schema.load({"data": data}))
+            self.assertEqual(schema.dump(A(data=data)), {"data": data})
+        for data in ["b", 2, 2.34, False]:
+            self.assertRaises(
+                ValidationError, lambda data=data: schema.load({"data": data})
+            )
 
     def test_validator_stacking(self):
         # See: https://github.com/lovasoa/marshmallow_dataclass/issues/91

--- a/tests/test_class_schema.py
+++ b/tests/test_class_schema.py
@@ -4,9 +4,9 @@ from typing import Any
 from uuid import UUID
 
 try:
-    from typing import Literal  # type: ignore
+    from typing import Literal
 except ImportError:
-    from typing_extensions import Literal
+    from typing_extensions import Literal  # type: ignore
 
 import dataclasses
 from marshmallow import Schema, ValidationError

--- a/tests/test_field_for_schema.py
+++ b/tests/test_field_for_schema.py
@@ -4,7 +4,12 @@ import unittest
 from enum import Enum
 from typing import Dict, Optional, Union, Any, List, Tuple
 
-from marshmallow import fields, Schema
+try:
+    from typing import Literal  # type: ignore
+except ImportError:
+    from typing_extensions import Literal
+
+from marshmallow import fields, Schema, validate
 
 from marshmallow_dataclass import field_for_schema, dataclass, union_field
 
@@ -86,6 +91,18 @@ class TestFieldForSchema(unittest.TestCase):
         self.assertFieldsEqual(
             field_for_schema(Color),
             marshmallow_enum.EnumField(enum=Color, required=True),
+        )
+
+    def test_literal(self):
+        self.assertFieldsEqual(
+            field_for_schema(Literal["a"]),
+            fields.Raw(required=True, validate=validate.Equal("a")),
+        )
+
+    def test_literal_multiple_types(self):
+        self.assertFieldsEqual(
+            field_for_schema(Literal["a", 1, 1.23, True]),
+            fields.Raw(required=True, validate=validate.OneOf(("a", 1, 1.23, True))),
         )
 
     def test_union(self):

--- a/tests/test_field_for_schema.py
+++ b/tests/test_field_for_schema.py
@@ -5,9 +5,9 @@ from enum import Enum
 from typing import Dict, Optional, Union, Any, List, Tuple
 
 try:
-    from typing import Literal  # type: ignore
+    from typing import Literal
 except ImportError:
-    from typing_extensions import Literal
+    from typing_extensions import Literal  # type: ignore
 
 from marshmallow import fields, Schema, validate
 


### PR DESCRIPTION
This PR adds support for the [`Literal`](https://www.python.org/dev/peps/pep-0586/) type.

This is my first contribution to `marshmallow-dataclass`. Let me know if you agree with the implementation and if there's anything missing.

Fixes #109.