### PR TITLE
Declare common types for type checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,8 +240,14 @@ from marshmallow_dataclass import NewType
 Email = NewType("Email", str, field=marshmallow.fields.Email)
 ```
 
+For convenience, some custom types are provided:
+
+```python
+from marshmallow_dataclass.typing import Email, Url
+```
+
 Note: if you are using `mypy`, you will notice that `mypy` throws an error if a variable defined with
-`NewType` is used in a type annotation. To resolve this, add the `marshmallow_dataclass.mypy` plugin 
+`NewType` is used in a type annotation. To resolve this, add the `marshmallow_dataclass.mypy` plugin
 to your `mypy` configuration, e.g.:
 
 ```ini

--- a/marshmallow_dataclass/typing.py
+++ b/marshmallow_dataclass/typing.py
@@ -1,0 +1,8 @@
+import marshmallow.fields
+from . import NewType
+
+Url = NewType("Url", str, field=marshmallow.fields.Url)
+Email = NewType("Email", str, field=marshmallow.fields.Email)
+
+# Aliases
+URL = Url

--- a/tests/test_mypy.yml
+++ b/tests/test_mypy.yml
@@ -37,3 +37,23 @@
         name: str
 
     user = User(id=4, name='Johny')
+- case: public_custom_types
+  mypy_config: |
+    follow_imports = silent
+    plugins = marshmallow_dataclass.mypy
+  main: |
+    from dataclasses import dataclass
+    import marshmallow
+    from marshmallow_dataclass.typing import Email, Url
+
+
+    @dataclass
+    class Website:
+        url: Url
+        email: Email
+
+    website = Website(url="http://www.example.org", email="admin@example.org")
+    reveal_type(website.url)  # N: Revealed type is 'builtins.str'
+    reveal_type(website.email)  # N: Revealed type is 'builtins.str'
+
+    Website(url=42, email="user@email.com")  # E: Argument "url" to "Website" has incompatible type "int"; expected "str"


### PR DESCRIPTION
Prevents each consumer declaring them on their side.

See #114