### PR TITLE
Do not pass "description" argument to marshmallow.Field

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -35,3 +35,5 @@ jobs:
       run: pre-commit run --all-files
     - name: Test with pytest
       run: pytest
+      env:
+        PYTHONWARNINGS=error

--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ To pass arguments to the generated marshmallow fields (e.g., `validate`, `load_o
 pass them to the `metadata` argument of the
 [`field`](https://docs.python.org/3/library/dataclasses.html#dataclasses.field) function.
 
+Note that starting with version 4, marshmallow will disallow passing arbitrary arguments, so any
+additional metadata should itself be put in its own `metadata` dict:
+
 ```python
 from dataclasses import dataclass, field
 import marshmallow_dataclass
@@ -107,7 +110,11 @@ import marshmallow.validate
 
 @dataclass
 class Person:
-    name: str = field(metadata=dict(load_only=True))
+    name: str = field(
+        metadata=dict(
+            load_only=True, metadata=dict(description="The person's first name")
+        )
+    )
     height: float = field(metadata=dict(validate=marshmallow.validate.Range(min=0)))
 
 

--- a/marshmallow_dataclass/__init__.py
+++ b/marshmallow_dataclass/__init__.py
@@ -395,7 +395,8 @@ def _field_by_supertype(
                 new_validators.append(meta_dict["validate"])
     metadata["validate"] = new_validators if new_validators else None
 
-    metadata = {"description": typ.__name__, **typ_args, **metadata}
+    metadata = {**typ_args, **metadata}
+    metadata.setdefault("metadata", {}).setdefault("description", typ.__name__)
     field = getattr(typ, "_marshmallow_field", None)
     if field:
         return field(**metadata)

--- a/tests/test_field_for_schema.py
+++ b/tests/test_field_for_schema.py
@@ -168,7 +168,9 @@ class TestFieldForSchema(unittest.TestCase):
     def test_newtype(self):
         self.assertFieldsEqual(
             field_for_schema(typing.NewType("UserId", int), default=0),
-            fields.Integer(required=False, description="UserId", default=0, missing=0),
+            fields.Integer(
+                required=False, default=0, missing=0, metadata={"description": "UserId"}
+            ),
         )
 
     def test_marshmallow_dataclass(self):


### PR DESCRIPTION
This should also be a fix for the initial issue reported in
https://github.com/lovasoa/marshmallow_dataclass/issues/119 (`description` is the problem here, not
the other arguments)

Note also the use of PYTHONWARNINGS=error to help detect these types of errors in the future.