### PR TITLE
Add MIT license trove classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,9 +6,12 @@ CLASSIFIERS = [
     "Development Status :: 4 - Beta",
     "Environment :: Console",
     "Operating System :: OS Independent",
+    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
     "Topic :: Internet :: WWW/HTTP :: Dynamic Content :: CGI Tools/Libraries",
 ]
 
@@ -51,6 +54,7 @@ setup(
     url="https://github.com/lovasoa/marshmallow_dataclass",
     keywords=["marshmallow", "dataclass", "serialization"],
     classifiers=CLASSIFIERS,
+    license="MIT",
     python_requires=">=3.6",
     install_requires=["marshmallow>=3.0.0,<4.0", "typing-inspect"],
     extras_require=EXTRAS_REQUIRE,


### PR DESCRIPTION
Allows the license to be detected properly by tools like `pip-licenses`