### PR TITLE
Proposal: add union serialization strategy

### DIFF
--- a/marshmallow_dataclass/__init__.py
+++ b/marshmallow_dataclass/__init__.py
@@ -61,11 +61,6 @@ from typing import (
 import marshmallow
 import typing_inspect
 
-# TODO: remove
-from icecream import install
-install()
-ic.configureOutput(includeContext=True)
-
 __all__ = ["dataclass", "add_schema", "class_schema", "field_for_schema", "NewType"]
 
 NoneType = type(None)
@@ -442,7 +437,6 @@ def _field_for_generic_type(
     """
     If the type is a generic interface, resolve the arguments and construct the appropriate Field.
     """
-    ic(metadata)
     origin = typing_inspect.get_origin(typ)
     if origin:
         arguments = typing_inspect.get_args(typ, True)
@@ -450,7 +444,6 @@ def _field_for_generic_type(
         type_mapping = base_schema.TYPE_MAPPING if base_schema else {}
 
         if origin in (list, List):
-            ic()
             child_type = field_for_schema(arguments[0], base_schema=base_schema, metadata=metadata)
             list_type = cast(
                 Type[marshmallow.fields.List],
@@ -495,7 +488,6 @@ def _field_for_generic_type(
                 **metadata,
             )
         elif typing_inspect.is_union_type(typ):
-            ic()
             if typing_inspect.is_optional_type(typ):
                 metadata["allow_none"] = metadata.get("allow_none", True)
                 metadata["default"] = metadata.get("default", None)
@@ -562,10 +554,7 @@ def field_for_schema(
     # If the field was already defined by the user
     predefined_field = metadata.get("marshmallow_field")
     if predefined_field:
-        ic("PREDEF")
         return predefined_field
-
-    ic(metadata, typ)
 
     # Generic types specified without type arguments
     typ = _generic_type_add_any(typ)

--- a/marshmallow_dataclass/union_field.py
+++ b/marshmallow_dataclass/union_field.py
@@ -1,8 +1,141 @@
 import copy
-from typing import List, Tuple, Any, Optional
+from typing import Callable, Dict, List, Tuple, Any, Optional, Type
 
 import typeguard
 from marshmallow import fields, Schema, ValidationError
+from abc import ABC, abstractmethod
+
+SERIALIZATION_STRATEGY_KEY = "serialization_strategy"
+
+
+class SerializationStrategy(ABC):
+
+    def __init__(self):
+        self._union_fields = []
+        self._required = False
+
+    def set_union_fields(self, union_fields):
+        self._union_fields = union_fields
+
+    def set_required(self, required):
+        self._required = required
+
+    @abstractmethod
+    def serialize(self, value: Any, attr: str, obj, **kwargs) -> Any:
+        pass
+
+    @abstractmethod
+    def deserialize(self, value: Any, attr: Optional[str], data, **kwargs) -> Any:
+        pass
+
+
+class FallbackSerializationStrategy(SerializationStrategy):
+
+    def serialize(self, value: Any, attr: str, obj, **kwargs) -> Any:
+        errors = []
+        if value is None and not self._required:
+            return value
+        for typ, field in self._union_fields:
+            try:
+                typeguard.check_type(attr, value, typ)
+                return field._serialize(value, attr, obj, **kwargs)
+            except TypeError as e:
+                errors.append(e)
+        raise TypeError(
+            f"Unable to serialize value with any of the fields in the union: {errors}"
+        )
+
+    def deserialize(self, value: Any, attr: Optional[str], data, **kwargs) -> Any:
+        errors = []
+        for typ, field in self._union_fields:
+            try:
+                result = field.deserialize(value, **kwargs)
+                typeguard.check_type(attr or "anonymous", result, typ)
+                return result
+            except (TypeError, ValidationError) as e:
+                errors.append(e)
+
+        raise ValidationError(errors)
+
+
+class NamedTypeSerializationStrategy(SerializationStrategy):
+
+    def __init__(self, type_to_name_map: Optional[Dict[Type, str]] = None, type_key="__type__", value_key="__value__"):
+        super().__init__()
+        self._type_to_name_map = type_to_name_map
+        self._type_key = type_key
+        self._value_key = value_key
+
+    def _get_field(self, type):
+        return next(f for t, f in self._union_fields if t == type)
+
+    def _compute_name_to_type_map(self):
+        self._name_to_type_map = None if self._type_to_name_map is None else {
+            n: (t, self._get_field(t)) for t, n in self._type_to_name_map.items()}
+
+    def set_union_fields(self, union_fields):
+        super().set_union_fields(union_fields)
+        if self._type_to_name_map is None:
+            self._type_to_name_map = {t: t.__name__ for t, _ in union_fields}
+        self._compute_name_to_type_map()
+
+    def serialize(self, value: Any, attr: str, obj, **kwargs) -> Any:
+        errors = []
+        if value is None and not self._required:
+            return value
+        for typ, field in self._union_fields:
+            try:
+                typeguard.check_type(attr, value, typ)
+                serialized = field._serialize(value, attr, obj, **kwargs)
+                if isinstance(serialized, dict):
+                    serialized[self._type_key] = self._type_to_name_map[typ]
+                else:
+                    serialized = {
+                        self._value_key: serialized,
+                        self._type_key: self._type_to_name_map[typ]
+                    }
+                return serialized
+            except TypeError as e:
+                errors.append(e)
+        raise TypeError(
+            f"Unable to serialize value with any of the fields in the union: {errors}"
+        )
+
+    def _validate(self, value: Any) -> Tuple[Type[Any], fields.Field]:
+        if not isinstance(value, dict):
+            raise TypeError("Expected value to be a dict")
+        if self._type_key not in value:
+            raise RuntimeError(f"Can't get object type, {self._type_key} not found")
+        
+        typ_name = value[self._type_key]
+
+        if typ_name not in self._name_to_type_map:
+            raise RuntimeError(f"Unknown type {typ_name}")
+
+        return self._name_to_type_map[typ_name]
+
+    def deserialize(self, value: Any, attr: Optional[str], data, **kwargs) -> Any:
+        typ, field = self._validate(value)
+        value = copy.copy(value)
+        del value[self._type_key]
+
+        errors = []
+
+        try:
+            result = field.deserialize(value, **kwargs)
+            typeguard.check_type(attr or "anonymous", result, typ)
+            return result
+        except (TypeError, ValidationError) as e:
+            errors.append(e)
+
+        try:
+            result = field.deserialize(value[self._value_key], **kwargs)
+            typeguard.check_type(attr or "anonymous", result, typ)
+            return result
+        except (TypeError, ValidationError, KeyError) as e:
+            errors.append(e)
+
+        raise ValidationError(errors)
 
 
 class Union(fields.Field):
@@ -21,8 +154,19 @@ class Union(fields.Field):
     """
 
     def __init__(self, union_fields: List[Tuple[type, fields.Field]], **kwargs):
+        kwargs = copy.deepcopy(kwargs)
+        self._serialization_strategy = self.__extract_serialization_strategy(kwargs)
         super().__init__(**kwargs)
+        self._serialization_strategy.set_union_fields(union_fields)
+        self._serialization_strategy.set_required(self.required)
         self.union_fields = union_fields
+
+    def __extract_serialization_strategy(self, metadata: dict):
+        serialization_strategy: SerializationStrategy = FallbackSerializationStrategy()
+        if SERIALIZATION_STRATEGY_KEY in metadata:
+            serialization_strategy = metadata[SERIALIZATION_STRATEGY_KEY]
+            # del metadata[SERIALIZATION_STRATEGY_KEY]
+        return serialization_strategy
 
     def _bind_to_schema(self, field_name: str, schema: Schema) -> None:
         super()._bind_to_schema(field_name, schema)
@@ -35,27 +179,7 @@ class Union(fields.Field):
         self.union_fields = new_union_fields
 
     def _serialize(self, value: Any, attr: str, obj, **kwargs) -> Any:
-        errors = []
-        if value is None and not self.required:
-            return value
-        for typ, field in self.union_fields:
-            try:
-                typeguard.check_type(attr, value, typ)
-                return field._serialize(value, attr, obj, **kwargs)
-            except TypeError as e:
-                errors.append(e)
-        raise TypeError(
-            f"Unable to serialize value with any of the fields in the union: {errors}"
-        )
+        return self._serialization_strategy.serialize(value, attr, obj, **kwargs)
 
     def _deserialize(self, value: Any, attr: Optional[str], data, **kwargs) -> Any:
-        errors = []
-        for typ, field in self.union_fields:
-            try:
-                result = field.deserialize(value, **kwargs)
-                typeguard.check_type(attr or "anonymous", result, typ)
-                return result
-            except (TypeError, ValidationError) as e:
-                errors.append(e)
-
-        raise ValidationError(errors)
+        return self._serialization_strategy.deserialize(value, attr, data, **kwargs)

--- a/marshmallow_dataclass/union_field.py
+++ b/marshmallow_dataclass/union_field.py
@@ -106,7 +106,7 @@ class NamedTypeSerializationStrategy(SerializationStrategy):
             raise TypeError("Expected value to be a dict")
         if self._type_key not in value:
             raise RuntimeError(f"Can't get object type, {self._type_key} not found")
-        
+
         typ_name = value[self._type_key]
 
         if typ_name not in self._name_to_type_map:

--- a/marshmallow_dataclass/union_field.py
+++ b/marshmallow_dataclass/union_field.py
@@ -1,12 +1,11 @@
 import copy
-from typing import Callable, Dict, List, Tuple, Any, Optional, Type
+from typing import Dict, List, Tuple, Any, Optional, Type
 
 import typeguard
 from marshmallow import fields, Schema, ValidationError
 from abc import ABC, abstractmethod
 
 SERIALIZATION_STRATEGY_KEY = "serialization_strategy"
-
 
 class SerializationStrategy(ABC):
 
@@ -165,7 +164,6 @@ class Union(fields.Field):
         serialization_strategy: SerializationStrategy = FallbackSerializationStrategy()
         if SERIALIZATION_STRATEGY_KEY in metadata:
             serialization_strategy = metadata[SERIALIZATION_STRATEGY_KEY]
-            # del metadata[SERIALIZATION_STRATEGY_KEY]
         return serialization_strategy
 
     def _bind_to_schema(self, field_name: str, schema: Schema) -> None:

--- a/tests/test_city_building_examples.py
+++ b/tests/test_city_building_examples.py
@@ -6,7 +6,6 @@ import marshmallow.validate
 
 import marshmallow_dataclass
 
-
 @dataclass
 class Building:
     # field metadata is used to instantiate the marshmallow field

--- a/tests/test_union.py
+++ b/tests/test_union.py
@@ -61,8 +61,6 @@ class TestClassSchema(unittest.TestCase):
             list: List[Union[Class1, Class2, Class3]] = field(metadata={
                 SERIALIZATION_STRATEGY_KEY: NamedTypeSerializationStrategy()
             })
-
-        ic()
         schema = ListOfClasses.Schema()
         data_in = {"list": [
             {
@@ -115,8 +113,7 @@ class TestClassSchema(unittest.TestCase):
                     type_key="I_am_the_type"
                 )
             })
-
-        ic()
+            
         schema = ListOfClasses.Schema()
         data_in = {"list": [
             {

--- a/tests/test_union.py
+++ b/tests/test_union.py
@@ -1,4 +1,4 @@
-from marshmallow_dataclass.union_field import FallbackSerializationStrategy, NamedTypeSerializationStrategy, SERIALIZATION_STRATEGY_KEY
+from marshmallow_dataclass.union_field import NamedTypeSerializationStrategy, SERIALIZATION_STRATEGY_KEY
 import unittest
 from typing import List, Optional, Union, Dict
 
@@ -113,7 +113,7 @@ class TestClassSchema(unittest.TestCase):
                     type_key="I_am_the_type"
                 )
             })
-            
+
         schema = ListOfClasses.Schema()
         data_in = {"list": [
             {


### PR DESCRIPTION
I would like to have the possibility to choose how unions are serialized and deserialized. The try-all-possibility strategy that is currently used is great for most of the cases, but when two or more types among the possible ones share the same schema it fails. Moreover, trying out all possible types can be time consuming.

Instead of this, my proposal is to let the user choose which strategy should be followed when serializing/deserializing a union. In particular I implemented the following two strategies:

- **Fallback**: tries all the types until it finds one that is successfully deserialized and validated (this is the default one)
- **TypeName**: during serialization adds an attribute with the name of the type that is used during deserialization to load the correct type. I let the user free to choose the key used for the type and the names used for types (if they don't specify them, class name is used by default)

The strategy to be used can be specified in metadata. If it is not specified, fallback is assumed.

The user can also implement new strategies if they want. 

There is another option to obtain what I wanted without modifying the code that is manually adding a type field to dataclasses in the union and then use validation to make deserialization fail in case the type is not the wanted one, but I found this a little hacky.

If you like this little contribution I will clean up the code and add some documentation about this new feature.

In any case thank you for this awesome little library!