### PR TITLE
Fix mypy tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ CLASSIFIERS = [
 EXTRAS_REQUIRE = {
     "enum": ["marshmallow-enum"],
     "union": ["typeguard"],
-    ':python_version == "3.6"': ["dataclasses"],
+    ':python_version == "3.6"': ["dataclasses", "types-dataclasses"],
     "lint": ["pre-commit~=1.18"],
     "docs": ["sphinx"],
     "tests": [

--- a/tests/test_mypy.yml
+++ b/tests/test_mypy.yml
@@ -19,8 +19,8 @@
         email: Email
 
     user = User(id="a"*32, email="user@email.com")
-    reveal_type(user.id)  # N: Revealed type is 'builtins.str'
-    reveal_type(user.email)  # N: Revealed type is 'builtins.str'
+    reveal_type(user.id)  # N: Revealed type is "builtins.str"
+    reveal_type(user.email)  # N: Revealed type is "builtins.str"
 
     User(id=42, email="user@email.com")  # E: Argument "id" to "User" has incompatible type "int"; expected "str"
     User(id="a"*32, email=["not", "a", "string"])  # E: Argument "email" to "User" has incompatible type "List[str]"; expected "str"
@@ -53,7 +53,7 @@
         email: Email
 
     website = Website(url="http://www.example.org", email="admin@example.org")
-    reveal_type(website.url)  # N: Revealed type is 'builtins.str'
-    reveal_type(website.email)  # N: Revealed type is 'builtins.str'
+    reveal_type(website.url)  # N: Revealed type is "builtins.str"
+    reveal_type(website.email)  # N: Revealed type is "builtins.str"
 
     Website(url=42, email="user@email.com")  # E: Argument "url" to "Website" has incompatible type "int"; expected "str"


### PR DESCRIPTION
Since mypy v0.900, double-quotes instead of single-quotes are used in error messages:
- https://github.com/python/mypy/commit/96cae4b1b0c2a4298ca8cb3e86d8dced30c9fff2
- https://github.com/python/mypy/compare/v0.812...v0.900

When the last CI pipeline ran, mypy v0.812 was used which is why no errors occurred.

Also, it seems mypy v0.900 requires type stubs for the dataclasses backport needed for Python 3.6. Just wondering, should types-dataclasses be a dependency of this library or rather of the dataclasses backport library?