### PR TITLE
Add warning about the limitations of type inference when using Final

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # marshmallow\_dataclass change log
 
-- Add support for the Final type. See [#150](https://github.com/lovasoa/marshmallow_dataclass/pull/150)
+- Add support for the Final type. See [#150](https://github.com/lovasoa/marshmallow_dataclass/pull/150) and [#151](https://github.com/lovasoa/marshmallow_dataclass/pull/151)
 
 ## v8.4.1
 

--- a/marshmallow_dataclass/__init__.py
+++ b/marshmallow_dataclass/__init__.py
@@ -585,6 +585,11 @@ def field_for_schema(
             subtyp = arguments[0]
         elif default is not marshmallow.missing:
             subtyp = type(default)
+            warnings.warn(
+                "Support for type inference from a default value is limited and may "
+                "result in inaccurate validation. Provide a type to Final[...] to "
+                "ensure accurate validation."
+            )
         else:
             subtyp = Any
         return field_for_schema(subtyp, default, metadata, base_schema)

--- a/marshmallow_dataclass/__init__.py
+++ b/marshmallow_dataclass/__init__.py
@@ -584,7 +584,9 @@ def field_for_schema(
         if arguments:
             subtyp = arguments[0]
         elif default is not marshmallow.missing:
-            subtyp = type(default)
+            raise NotImplementedError(
+                "Type inference from default value is not supported"
+            )
         else:
             subtyp = Any
         return field_for_schema(subtyp, default, metadata, base_schema)

--- a/marshmallow_dataclass/__init__.py
+++ b/marshmallow_dataclass/__init__.py
@@ -584,17 +584,31 @@ def field_for_schema(
         if arguments:
             subtyp = arguments[0]
         elif default is not marshmallow.missing:
-            subtyp = type(default)
-            warnings.warn(
-                "****** WARNING ****** "
-                "marshmallow_dataclass was called on a dataclass with an attribute "
-                'that is type-annotated with "Final" with a default value from which '
-                "the Marshmallow field type is inferred. Support for type inference "
-                "from a default value is limited and may result in inaccurate "
-                "validation. Provide a type to Final[...] to ensure accurate "
-                "validation. "
-                "****** WARNING ******"
-            )
+            if callable(default):
+                subtyp = Any
+                warnings.warn(
+                    "****** WARNING ****** "
+                    "marshmallow_dataclass was called on a dataclass with an "
+                    'attribute that is type-annotated with "Final" and uses '
+                    "dataclasses.field for specifying a default value using a "
+                    "factory. The Marshmallow field type cannot be inferred from the "
+                    "factory and will fall back to a raw field which is equivalent to "
+                    'the type annotation "Any" and will result in no validation. '
+                    "Provide a type to Final[...] to ensure accurate validation. "
+                    "****** WARNING ******"
+                )
+            else:
+                subtyp = type(default)
+                warnings.warn(
+                    "****** WARNING ****** "
+                    "marshmallow_dataclass was called on a dataclass with an "
+                    'attribute that is type-annotated with "Final" with a default '
+                    "value from which the Marshmallow field type is inferred. "
+                    "Support for type inference from a default value is limited and "
+                    "may result in inaccurate validation. Provide a type to "
+                    "Final[...] to ensure accurate validation. "
+                    "****** WARNING ******"
+                )
         else:
             subtyp = Any
         return field_for_schema(subtyp, default, metadata, base_schema)

--- a/marshmallow_dataclass/__init__.py
+++ b/marshmallow_dataclass/__init__.py
@@ -586,9 +586,14 @@ def field_for_schema(
         elif default is not marshmallow.missing:
             subtyp = type(default)
             warnings.warn(
-                "Support for type inference from a default value is limited and may "
-                "result in inaccurate validation. Provide a type to Final[...] to "
-                "ensure accurate validation."
+                "****** WARNING ****** "
+                "marshmallow_dataclass was called on a dataclass with an attribute "
+                'that is type-annotated with "Final" with a default value from which '
+                "the Marshmallow field type is inferred. Support for type inference "
+                "from a default value is limited and may result in inaccurate "
+                "validation. Provide a type to Final[...] to ensure accurate "
+                "validation. "
+                "****** WARNING ******"
             )
         else:
             subtyp = Any

--- a/marshmallow_dataclass/__init__.py
+++ b/marshmallow_dataclass/__init__.py
@@ -584,9 +584,7 @@ def field_for_schema(
         if arguments:
             subtyp = arguments[0]
         elif default is not marshmallow.missing:
-            raise NotImplementedError(
-                "Type inference from default value is not supported"
-            )
+            subtyp = type(default)
         else:
             subtyp = Any
         return field_for_schema(subtyp, default, metadata, base_schema)

--- a/tests/test_class_schema.py
+++ b/tests/test_class_schema.py
@@ -192,7 +192,8 @@ class TestClassSchema(unittest.TestCase):
             A = dataclasses.dataclass(A)
             B = dataclasses.dataclass(B)
 
-        schema_a = class_schema(A)()
+        with self.assertWarns(Warning):
+            schema_a = class_schema(A)()
         self.assertEqual(A(data="a"), schema_a.load({}))
         self.assertEqual(A(data="a"), schema_a.load({"data": "a"}))
         self.assertEqual(A(data="b"), schema_a.load({"data": "b"}))
@@ -203,7 +204,8 @@ class TestClassSchema(unittest.TestCase):
             with self.assertRaises(ValidationError):
                 schema_a.load({"data": data})
 
-        schema_b = class_schema(B)()
+        with self.assertWarns(Warning):
+            schema_b = class_schema(B)()
         self.assertEqual(B(data=A()), schema_b.load({}))
         self.assertEqual(B(data=A()), schema_b.load({"data": {}}))
         self.assertEqual(B(data=A()), schema_b.load({"data": {"data": "a"}}))

--- a/tests/test_class_schema.py
+++ b/tests/test_class_schema.py
@@ -177,44 +177,18 @@ class TestClassSchema(unittest.TestCase):
             with self.assertRaises(ValidationError):
                 schema.load({"data": data})
 
-    def test_final_infers_type_from_default(self):
+    def test_final_infers_type_from_default_not_implemented(self):
         # @dataclasses.dataclass
         class A:
             data: Final = "a"
 
-        # @dataclasses.dataclass
-        class B:
-            data: Final = A()
-
         # NOTE: This workaround is needed to avoid a Mypy crash.
-        # See: https://github.com/python/mypy/issues/10090#issuecomment-865971891
+        # See: https://github.com/python/mypy/issues/10090#issuecomment-866686096
         if not TYPE_CHECKING:
             A = dataclasses.dataclass(A)
-            B = dataclasses.dataclass(B)
 
-        schema_a = class_schema(A)()
-        self.assertEqual(A(data="a"), schema_a.load({}))
-        self.assertEqual(A(data="a"), schema_a.load({"data": "a"}))
-        self.assertEqual(A(data="b"), schema_a.load({"data": "b"}))
-        self.assertEqual(schema_a.dump(A()), {"data": "a"})
-        self.assertEqual(schema_a.dump(A(data="a")), {"data": "a"})
-        self.assertEqual(schema_a.dump(A(data="b")), {"data": "b"})
-        for data in [2, 2.34, False]:
-            with self.assertRaises(ValidationError):
-                schema_a.load({"data": data})
-
-        schema_b = class_schema(B)()
-        self.assertEqual(B(data=A()), schema_b.load({}))
-        self.assertEqual(B(data=A()), schema_b.load({"data": {}}))
-        self.assertEqual(B(data=A()), schema_b.load({"data": {"data": "a"}}))
-        self.assertEqual(B(data=A(data="b")), schema_b.load({"data": {"data": "b"}}))
-        self.assertEqual(schema_b.dump(B()), {"data": {"data": "a"}})
-        self.assertEqual(schema_b.dump(B(data=A())), {"data": {"data": "a"}})
-        self.assertEqual(schema_b.dump(B(data=A(data="a"))), {"data": {"data": "a"}})
-        self.assertEqual(schema_b.dump(B(data=A(data="b"))), {"data": {"data": "b"}})
-        for data in [2, 2.34, False]:
-            with self.assertRaises(ValidationError):
-                schema_b.load({"data": data})
+        with self.assertRaises(NotImplementedError):
+            class_schema(A)
 
     def test_validator_stacking(self):
         # See: https://github.com/lovasoa/marshmallow_dataclass/issues/91


### PR DESCRIPTION
Unfortunately, I implemented type inference from a default value when using `Final` incorrectly in #150, i.e. it only works for simple cases, but it's actually not true type inference. I'm not sure whether it's currently possible to get the type hint inferred from the default value at runtime.

E.g.:

```python
@dataclasses.dataclass
class A:
    data: Final = dataclasses.field(default_factory=lambda: [1, "a"])  # inferred as `list[int | str]`
```

1. The implementation in #150 does not support `dataclasses.field(...)`, but this could be fixed.
2. The implementation in #150 would at best infer the default value to have the type `list` but cannot infer `List[Union[int, str]]`. In order to get the correct type, actual type inference is be needed.

This PR changes the behavior, so that a `NotImplementedError` is raised when `Final` has no argument and a default value exists. I don't think it's a big problem to not support this case because type inference is just a convenience. Instead, `Final[...]` could always be typed explicitly.

Sorry for the sloppiness in #150 ...