### PR TITLE
Support Final field with a default factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # marshmallow\_dataclass change log
 
-- Add support for the Final type. See [#150](https://github.com/lovasoa/marshmallow_dataclass/pull/150)
+- Add support for the Final type. See [#150](https://github.com/lovasoa/marshmallow_dataclass/pull/150) and [#152](https://github.com/lovasoa/marshmallow_dataclass/pull/152)
 
 ## v8.4.1
 

--- a/marshmallow_dataclass/__init__.py
+++ b/marshmallow_dataclass/__init__.py
@@ -584,7 +584,10 @@ def field_for_schema(
         if arguments:
             subtyp = arguments[0]
         elif default is not marshmallow.missing:
-            subtyp = type(default)
+            # We can safely assume that if `default` is a callable then it is a
+            # factory for a default value because callable dataclass attributes
+            # don't make sense to be (de)serialized using Marshmallow.
+            subtyp = type(default() if callable(default) else default)
         else:
             subtyp = Any
         return field_for_schema(subtyp, default, metadata, base_schema)


### PR DESCRIPTION
This PR adds support for using `Final` with a field and a default factory:

```python
@dataclasses.dataclass
class A:
    data: Final = dataclasses.field(default_factory=lambda: ["a", 1])
```

Extends #150.