### PR TITLE
Add support for builtin generics available in python 3.9

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python_version: [3.6, 3.7, 3.8, pypy3]
+        python_version: [3.6, 3.7, 3.8, 3.9, pypy3]
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     classifiers=CLASSIFIERS,
     license="MIT",
     python_requires=">=3.6",
-    install_requires=["marshmallow>=3.0.0,<4.0", "typing-inspect>=0.7.0"],
+    install_requires=["marshmallow>=3.0.0,<4.0", "typing-inspect>=0.7.1"],
     extras_require=EXTRAS_REQUIRE,
     package_data={"marshmallow_dataclass": ["py.typed"]},
 )

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -1,4 +1,5 @@
 import itertools
+import sys
 import unittest
 from typing import Optional, Sequence, Set, FrozenSet, Mapping
 
@@ -336,3 +337,26 @@ class TestMappingField(unittest.TestCase):
             {"value": {1: {"name": "Doe"}}},
         ):
             self.assertEqual(schema.dump(schema.load(data_in)), data_in)
+
+
+class TestBuiltinGenerics(unittest.TestCase):
+    @unittest.skipIf(
+        sys.version_info < (3, 9),
+        "builtin generics are only available in python 3.9 upwards",
+    )
+    def test_builtin(self):
+        annotations = [list[int], dict[str, int], set[str]]
+        samples = [[1, 2, 3], {"foo": 1, "bar": 2}, {"f", "o", "b", "a", "r"}]
+
+        for annotation, sample in zip(annotations, samples):
+            with self.subTest(f"Testing {annotation}"):
+
+                @dataclass
+                class Dummy:
+                    value: annotation
+
+                schema = Dummy.Schema()
+
+                # check if a round trip keeps the data untouched
+                loaded = schema.load(schema.dump(Dummy(value=sample)))
+                self.assertEqual(loaded, Dummy(value=sample))


### PR DESCRIPTION
 - Bumpy required version of typing_inspect to 0.7.1
 - Add minimal unittest for builtin generics
 - Modify github actions to also built on python 3.9 image

This max fix #136 