### PR TITLE
Allow setting `required=True` on fields of type `Optional`

### DIFF
--- a/marshmallow_dataclass/__init__.py
+++ b/marshmallow_dataclass/__init__.py
@@ -491,8 +491,9 @@ def _field_for_generic_type(
             if typing_inspect.is_optional_type(typ):
                 metadata["allow_none"] = metadata.get("allow_none", True)
                 metadata["dump_default"] = metadata.get("dump_default", None)
-                metadata["load_default"] = metadata.get("load_default", None)
-                metadata["required"] = False
+                if not metadata.get("required"):
+                    metadata["load_default"] = metadata.get("load_default", None)
+                metadata.setdefault("required", False)
             subtypes = [t for t in arguments if t is not NoneType]  # type: ignore
             if len(subtypes) == 1:
                 return field_for_schema(
@@ -549,7 +550,7 @@ def field_for_schema(
         if not metadata.get("required"):
             metadata.setdefault("load_default", default)
     else:
-        metadata.setdefault("required", True)
+        metadata.setdefault("required", not typing_inspect.is_optional_type(typ))
 
     # If the field was already defined by the user
     predefined_field = metadata.get("marshmallow_field")

--- a/tests/test_optional.py
+++ b/tests/test_optional.py
@@ -41,7 +41,7 @@ class TestOptionalField(unittest.TestCase):
     def test_required_optional_field(self):
         @dataclass
         class RequiredOptionalValue:
-            value: Optional[int] = field(default=42, metadata={"required": True})
+            value: Optional[str] = field(default="default", metadata={"required": True})
 
         schema = RequiredOptionalValue.Schema()
 

--- a/tests/test_optional.py
+++ b/tests/test_optional.py
@@ -37,3 +37,20 @@ class TestOptionalField(unittest.TestCase):
         self.assertEqual(
             exc_cm.exception.messages, {"value": ["Field may not be null."]}
         )
+
+    def test_required_optional_field(self):
+        @dataclass
+        class RequiredOptionalValue:
+            value: Optional[int] = field(default=42, metadata={"required": True})
+
+        schema = RequiredOptionalValue.Schema()
+
+        self.assertEqual(schema.load({"value": None}), RequiredOptionalValue(None))
+        self.assertEqual(
+            schema.load({"value": "hello"}), RequiredOptionalValue(value="hello")
+        )
+        with self.assertRaises(marshmallow.exceptions.ValidationError) as exc_cm:
+            schema.load({})
+        self.assertEqual(
+            exc_cm.exception.messages, {"value": ["Missing data for required field."]}
+        )


### PR DESCRIPTION
As things currently are, `marshmallow-dataclass` [always forces `required=False`][1] on fields with `Optional` type.  It would be useful to be able to set `required=True` on such fields.

[1]: <https://github.com/lovasoa/marshmallow_dataclass/blob/05418800ccdaf158826bb34ceb12fc5c75daa266/marshmallow_dataclass/__init__.py#L495>

For example, if I write:
```py
@dataclass
class Data:
    x: Optional[int] = field(default=0, metadata={'required': True})
```
then, on deserialization, it should be required that a value for `x` — either an integer or `None` — be present.

Currently, `marshmallow-dataclass` forces `required=False` and `load_default=None` on the schema field, so that
`Data.Schema().load({})` will succeed, returning `Data(x=None)`.  I would like to be able to configure things so that, instead, `Data.Schema().load({})` raises `ValidationError("Missing data for required field")`.

This PR does that.