### PR TITLE
Fix bug (exposed by #159) in serialization of optional union types

### DIFF
--- a/marshmallow_dataclass/union_field.py
+++ b/marshmallow_dataclass/union_field.py
@@ -36,7 +36,7 @@ class Union(fields.Field):
 
     def _serialize(self, value: Any, attr: str, obj, **kwargs) -> Any:
         errors = []
-        if value is None and not self.required:
+        if value is None:
             return value
         for typ, field in self.union_fields:
             try:

--- a/tests/test_union.py
+++ b/tests/test_union.py
@@ -1,3 +1,4 @@
+from dataclasses import field
 import unittest
 from typing import List, Optional, Union, Dict
 
@@ -154,3 +155,14 @@ class TestClassSchema(unittest.TestCase):
 
         for data_in in [{"value": None}, {}]:
             self.assertEqual(schema.dump(schema.load(data_in)), {"value": None})
+
+    def test_required_optional_simple_union(self):
+        @dataclass
+        class Dclass:
+            value: Optional[Union[int, str]] = field(metadata={"required": True})
+
+        schema = Dclass.Schema()
+
+        for value in None, 42, "strvar":
+            self.assertEqual(schema.dump(Dclass(value=value)), {"value": value})
+            self.assertEqual(schema.load({"value": value}), Dclass(value=value))


### PR DESCRIPTION
The logic in `Union._serialize` on when to pass through a value of `None` was flawed.

It was checking its `required` attribute, and was only passing on `None` values when `required=False`.  This didn't matter before #159, when `required=False` was forced for all `Optional` fields. Now that `required=True` can be set, doing so causes a spurious [TypeError("Unable to serialize value with any of the fields in the union")][te], when attempting to serialize a `None`-valued union field.

[te]: <https://github.com/lovasoa/marshmallow_dataclass/blob/248fe32f0e79a668ff45c7e310e1ac81e9eb9dc2/marshmallow_dataclass/union_field.py#L47>

I originally changed that to check the `allow_none` attribute for the field.  Looking at the source for Marshmallow, however, it seems that the `_serialize` methods for the stock Marshmallow field types [unconditionally][5] just [return][1] any `None` [values][3] (without regard for any `required`, `allow_none`, or other options set on the field.)  This makes sense, I guess, since data validation is only really performed during deserialization.  During serialization, it is assumed that the python-side data is correct.

[1]: <https://github.com/marshmallow-code/marshmallow/blob/afe4ddfa173ce717af281130a7532509de297d1e/src/marshmallow/fields.py#L621>
[2]: <https://github.com/marshmallow-code/marshmallow/blob/afe4ddfa173ce717af281130a7532509de297d1e/src/marshmallow/fields.py#L694>
[3]: <https://github.com/marshmallow-code/marshmallow/blob/afe4ddfa173ce717af281130a7532509de297d1e/src/marshmallow/fields.py#L755>
[4]: <https://github.com/marshmallow-code/marshmallow/blob/afe4ddfa173ce717af281130a7532509de297d1e/src/marshmallow/fields.py#L831>
[5]: <https://github.com/marshmallow-code/marshmallow/blob/afe4ddfa173ce717af281130a7532509de297d1e/src/marshmallow/fields.py#L874>

Given that observation, this PR changes `Union._serialize` so that it always returns `None` when `value` is `None`.