### PR TITLE
Proposed fix for #161

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # marshmallow\_dataclass change log
 
+## v8.5.3
+
+- Fix spurious `ValueError` when defining a Union field with explicit default value
+  ([#161](https://github.com/lovasoa/marshmallow_dataclass/pull/161))
+
 ## v8.5.2
 
 - Fix spurious `TypeError` when serializing `Optional` union types with `required=True`

--- a/marshmallow_dataclass/__init__.py
+++ b/marshmallow_dataclass/__init__.py
@@ -506,7 +506,7 @@ def _field_for_generic_type(
                     (
                         subtyp,
                         field_for_schema(
-                            subtyp, metadata=metadata, base_schema=base_schema
+                            subtyp, metadata={"required": True}, base_schema=base_schema
                         ),
                     )
                     for subtyp in subtypes

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-VERSION = "8.5.2"
+VERSION = "8.5.3"
 
 CLASSIFIERS = [
     "Development Status :: 4 - Beta",

--- a/tests/test_field_for_schema.py
+++ b/tests/test_field_for_schema.py
@@ -139,24 +139,8 @@ class TestFieldForSchema(unittest.TestCase):
             field_for_schema(Union[int, str, None]),
             union_field.Union(
                 [
-                    (
-                        int,
-                        fields.Integer(
-                            allow_none=True,
-                            required=False,
-                            dump_default=None,
-                            load_default=None,
-                        ),
-                    ),
-                    (
-                        str,
-                        fields.String(
-                            allow_none=True,
-                            required=False,
-                            dump_default=None,
-                            load_default=None,
-                        ),
-                    ),
+                    (int, fields.Integer(required=True)),
+                    (str, fields.String(required=True)),
                 ],
                 required=False,
                 dump_default=None,
@@ -169,24 +153,8 @@ class TestFieldForSchema(unittest.TestCase):
             field_for_schema(Optional[Union[int, str]]),
             union_field.Union(
                 [
-                    (
-                        int,
-                        fields.Integer(
-                            allow_none=True,
-                            required=False,
-                            dump_default=None,
-                            load_default=None,
-                        ),
-                    ),
-                    (
-                        str,
-                        fields.String(
-                            allow_none=True,
-                            required=False,
-                            dump_default=None,
-                            load_default=None,
-                        ),
-                    ),
+                    (int, fields.Integer(required=True)),
+                    (str, fields.String(required=True)),
                 ],
                 required=False,
                 dump_default=None,

--- a/tests/test_union.py
+++ b/tests/test_union.py
@@ -166,3 +166,17 @@ class TestClassSchema(unittest.TestCase):
         for value in None, 42, "strvar":
             self.assertEqual(schema.dump(Dclass(value=value)), {"value": value})
             self.assertEqual(schema.load({"value": value}), Dclass(value=value))
+
+    def test_union_with_default(self):
+        @dataclass
+        class IntOrStrWithDefault:
+            value: Union[int, str] = 42
+
+        schema = IntOrStrWithDefault.Schema()
+        self.assertEqual(schema.load({}), IntOrStrWithDefault(value=42))
+        for value in 13, "strval":
+            self.assertEqual(
+                schema.load({"value": value}), IntOrStrWithDefault(value=value)
+            )
+        with self.assertRaises(marshmallow.exceptions.ValidationError):
+            schema.load({"value": None})


### PR DESCRIPTION
Here is a proposed fix for #161.

Before you merge this, you might want to sit and think on it a bit to make sure that my logic is sound, but I'm thinking that the component fields of the `Union` field should all have `required=True` set.

The `Union` field itself (in its `deserialize` and `serialize` methods) handles the logic having to do with its `required`, `load_default`, `allow_none`, and `dump_default` options.  The component union_fields are only used for serializing and deserializing non-default/non-null values.  We don't want them to fill in default values or pass through `None`.