### PR TITLE
Fix use of typing.NewType in Python 3.10

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python_version: [3.6, 3.7, 3.8, 3.9, pypy3]
+        python_version: ["3.6", "3.7", "3.8", "3.9", "3.10", "pypy3"]
 
     steps:
     - uses: actions/checkout@v2

--- a/marshmallow_dataclass/__init__.py
+++ b/marshmallow_dataclass/__init__.py
@@ -595,9 +595,10 @@ def field_for_schema(
     if generic_field:
         return generic_field
 
-    # typing.NewType returns a function with a __supertype__ attribute
-    newtype_supertype = getattr(typ, "__supertype__", None)
-    if newtype_supertype and inspect.isfunction(typ):
+    # typing.NewType returns a function (in python <= 3.9) or a class (python >= 3.10) with a
+    # __supertype__ attribute
+    if typing_inspect.is_new_type(typ):
+        newtype_supertype = getattr(typ, "__supertype__", None)
         return _field_by_supertype(
             typ=typ,
             default=default,

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ CLASSIFIERS = [
 EXTRAS_REQUIRE = {
     "enum": ["marshmallow-enum"],
     "union": ["typeguard"],
-    ':python_version == "3.6"': ["dataclasses", "types-dataclasses"],
+    ':python_version == "3.6"': ["dataclasses", "types-dataclasses<0.6.4"],
     "lint": ["pre-commit~=1.18"],
     "docs": ["sphinx"],
     "tests": [


### PR DESCRIPTION
https://docs.python.org/3.10/library/typing.html#typing.NewType

"Changed in version 3.10: NewType is now a class rather than a function."

Also add Python 3.10 to the list of tested versions in GitHub workflow.