### PR TITLE
Fix thread-local recursion guard initialization

### DIFF
--- a/marshmallow_dataclass/__init__.py
+++ b/marshmallow_dataclass/__init__.py
@@ -80,7 +80,6 @@ MAX_CLASS_SCHEMA_CACHE_SIZE = 1024
 
 # Recursion guard for class_schema()
 _RECURSION_GUARD = threading.local()
-_RECURSION_GUARD.seen_classes = {}
 
 
 @overload
@@ -352,6 +351,7 @@ def class_schema(
             clazz_frame = current_frame.f_back
         # Per https://docs.python.org/3/library/inspect.html#the-interpreter-stack
         del current_frame
+    _RECURSION_GUARD.seen_classes = {}
     try:
         return _internal_class_schema(clazz, base_schema, clazz_frame)
     finally:


### PR DESCRIPTION
Thread-local variables must be initialized at runtime (i.e. in their
own thread), not globally at import time.

Fixes https://github.com/lovasoa/marshmallow_dataclass/issues/190