### PR TITLE
Add support for literal enums

### DIFF
--- a/marshmallow_dataclass/__init__.py
+++ b/marshmallow_dataclass/__init__.py
@@ -40,7 +40,7 @@ import inspect
 import threading
 import types
 import warnings
-from enum import EnumMeta
+from enum import Enum, EnumMeta
 from functools import lru_cache, partial
 from typing import (
     Any,
@@ -648,7 +648,22 @@ def field_for_schema(
 
     if typing_inspect.is_literal_type(typ):
         arguments = typing_inspect.get_args(typ)
-        return marshmallow.fields.Raw(
+
+        field_type = marshmallow.fields.Raw
+
+        # If all fields are an enum of the same type, interpret our literal as
+        # an enum instead.
+        if (
+            len(arguments) > 0
+            and isinstance(arguments[0], Enum)
+            and all(type(arguments[0]) == type(arg) for arg in arguments)
+        ):
+            import marshmallow_enum
+
+            metadata["enum"] = type(arguments[0])
+            field_type = marshmallow_enum.EnumField
+
+        return field_type(
             validate=(
                 marshmallow.validate.Equal(arguments[0])
                 if len(arguments) == 1

--- a/tests/test_field_for_schema.py
+++ b/tests/test_field_for_schema.py
@@ -19,6 +19,12 @@ from marshmallow_dataclass import (
 )
 
 
+class Color(Enum):
+    RED = 1
+    GREEN = 2
+    BLUE = 3
+
+
 class TestFieldForSchema(unittest.TestCase):
     def assertFieldsEqual(self, a: fields.Field, b: fields.Field):
         self.assertEqual(a.__class__, b.__class__, "field class")
@@ -90,11 +96,6 @@ class TestFieldForSchema(unittest.TestCase):
     def test_enum(self):
         import marshmallow_enum
 
-        class Color(Enum):
-            RED: 1
-            GREEN: 2
-            BLUE: 3
-
         self.assertFieldsEqual(
             field_for_schema(Color),
             marshmallow_enum.EnumField(enum=Color, required=True),
@@ -110,6 +111,16 @@ class TestFieldForSchema(unittest.TestCase):
         self.assertFieldsEqual(
             field_for_schema(Literal["a", 1, 1.23, True]),
             fields.Raw(required=True, validate=validate.OneOf(("a", 1, 1.23, True))),
+        )
+
+    def test_literal_enum(self):
+        import marshmallow_enum
+
+        self.assertFieldsEqual(
+            field_for_schema(Literal[Color.BLUE]),
+            marshmallow_enum.EnumField(
+                required=True, enum=Color, validate=validate.Equal(Color.BLUE)
+            ),
         )
 
     def test_final(self):


### PR DESCRIPTION
Consider the following code:

```python
from enum import Enum
from dataclasses import dataclass
from typing import Literal
import marshmallow_dataclass


class Color(Enum):
  RED = 0
  GREEN = 1
  BLUE = 2


@dataclass
class Dc:
  color: Literal[Color.RED]


print(marshmallow_dataclass.class_schema(Dc)().load({"color": "RED"}))
```

This will currently raise an exception, complaining `"RED"` is not equal to `Color.RED`. This is because `Literal` fields use `marshmallow.fields.Raw`, which does not reinterpret the string as an enum.

This patch instead interprets the string as an enum _if all literal values are of the same enum type_, meaning the above code now works.

This is not a more general fix - for instance, `Literal[Color.RED, Animal.DOG]` will still not work. Fixing this is definitely possible, but would require a more complex solution and I wasn't sure it was worth it. Happy to implement it though if you'd prefer!