### PR TITLE
Add UnionType workaround

### DIFF
--- a/marshmallow_dataclass/__init__.py
+++ b/marshmallow_dataclass/__init__.py
@@ -72,6 +72,11 @@ __all__ = ["dataclass", "add_schema", "class_schema", "field_for_schema", "NewTy
 NoneType = type(None)
 _U = TypeVar("_U")
 
+try:
+    UnionType = types.UnionType
+except AttributeError:
+    UnionType = None  # type: ignore
+
 # Whitelist of dataclass members that will be copied to generated schema.
 MEMBERS_WHITELIST: Set[str] = {"Meta"}
 
@@ -493,6 +498,10 @@ def _field_for_generic_type(
     """
     If the type is a generic interface, resolve the arguments and construct the appropriate Field.
     """
+    # Workaround for new Python 3.10 UnionType (int | str)
+    if UnionType and isinstance(typ, UnionType):
+        typ = cast(type, Union[typ.__args__])
+
     origin = typing_inspect.get_origin(typ)
     if origin:
         arguments = typing_inspect.get_args(typ, True)

--- a/tests/test_union.py
+++ b/tests/test_union.py
@@ -1,3 +1,4 @@
+import sys
 from dataclasses import field
 import unittest
 from typing import List, Optional, Union, Dict
@@ -180,3 +181,18 @@ class TestClassSchema(unittest.TestCase):
             )
         with self.assertRaises(marshmallow.exceptions.ValidationError):
             schema.load({"value": None})
+
+    @unittest.skipIf(
+        sys.version_info < (3, 10),
+        "simplified union syntax is only available in python 3.10 upwards",
+    )
+    def test_simplified_union(self):
+        @dataclass
+        class IntOrStr:
+            value: int | str | None
+
+        schema = IntOrStr.Schema()
+
+        for value in None, 42, "strvar":
+            self.assertEqual(schema.dump(IntOrStr(value=value)), {"value": value})
+            self.assertEqual(schema.load({"value": value}), IntOrStr(value=value))


### PR DESCRIPTION
Since UnionType from Python 3.10 currently unsupported in `typing_inspect` added workaround to use `type | type` syntax in dataclasses.