### PR TITLE
Fix broken user types after typing-inspect 0.8.0

### DIFF
--- a/marshmallow_dataclass/__init__.py
+++ b/marshmallow_dataclass/__init__.py
@@ -806,7 +806,8 @@ def NewType(
     marshmallow.exceptions.ValidationError: {'mail': ['Not a valid email address.']}
     """
 
-    new_type = _NewType(name, typ)
+    # noinspection PyTypeHints
+    new_type = _NewType(name, typ)  # type: ignore
     # noinspection PyTypeHints
     new_type._marshmallow_field = field  # type: ignore
     # noinspection PyTypeHints

--- a/marshmallow_dataclass/__init__.py
+++ b/marshmallow_dataclass/__init__.py
@@ -48,6 +48,7 @@ from typing import (
     Dict,
     List,
     Mapping,
+    NewType as _NewType,
     Optional,
     Set,
     Tuple,
@@ -805,12 +806,7 @@ def NewType(
     marshmallow.exceptions.ValidationError: {'mail': ['Not a valid email address.']}
     """
 
-    def new_type(x: _U):
-        return x
-
-    new_type.__name__ = name
-    # noinspection PyTypeHints
-    new_type.__supertype__ = typ  # type: ignore
+    new_type = _NewType(name, typ)
     # noinspection PyTypeHints
     new_type._marshmallow_field = field  # type: ignore
     # noinspection PyTypeHints


### PR DESCRIPTION
Since the recent release of `typing-inspect` 0.8.0, it's `is_new_type()` check expects the new type to come from the `typing` or `typing_extensions` module. When using local `NewType`, this condition isn't met.

The fix makes use of the `typing.NewType` and only adds the `marshmallow_dataclass` specific fields.

