### PR TITLE
fix(ci): Don't install the library editable

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install --pre -e '.[dev]'
+        pip install --pre '.[dev]'
     - name: Pre-commit hooks
       if: ${{ matrix.python_version != 'pypy3' && matrix.python_version != '3.6' }}
       run: pre-commit run --all-files


### PR DESCRIPTION
[Using the editable mode breaks path-finding capabilities of mypy](https://github.com/lovasoa/marshmallow_dataclass/pull/207#issuecomment-1222570537), which then fails for PRs.

Let's fix this so the CI checks work.