### PR TITLE
A couple of fixes to make CI tests more resilient

### DIFF
--- a/marshmallow_dataclass/__init__.py
+++ b/marshmallow_dataclass/__init__.py
@@ -48,6 +48,7 @@ from typing import (
     Dict,
     List,
     Mapping,
+    NewType as typing_NewType,
     Optional,
     Set,
     Tuple,
@@ -805,12 +806,8 @@ def NewType(
     marshmallow.exceptions.ValidationError: {'mail': ['Not a valid email address.']}
     """
 
-    def new_type(x: _U):
-        return x
-
-    new_type.__name__ = name
     # noinspection PyTypeHints
-    new_type.__supertype__ = typ  # type: ignore
+    new_type = typing_NewType(name, typ)  # type: ignore
     # noinspection PyTypeHints
     new_type._marshmallow_field = field  # type: ignore
     # noinspection PyTypeHints

--- a/marshmallow_dataclass/union_field.py
+++ b/marshmallow_dataclass/union_field.py
@@ -34,13 +34,15 @@ class Union(fields.Field):
 
         self.union_fields = new_union_fields
 
-    def _serialize(self, value: Any, attr: str, obj, **kwargs) -> Any:
+    def _serialize(self, value: Any, attr: Optional[str], obj, **kwargs) -> Any:
         errors = []
         if value is None:
             return value
         for typ, field in self.union_fields:
             try:
-                typeguard.check_type(attr, value, typ)
+                typeguard.check_type(
+                    value=value, expected_type=typ, argname=attr or "anonymous"
+                )
                 return field._serialize(value, attr, obj, **kwargs)
             except TypeError as e:
                 errors.append(e)
@@ -53,7 +55,9 @@ class Union(fields.Field):
         for typ, field in self.union_fields:
             try:
                 result = field.deserialize(value, **kwargs)
-                typeguard.check_type(attr or "anonymous", result, typ)
+                typeguard.check_type(
+                    value=result, expected_type=typ, argname=attr or "anonymous"
+                )
                 return result
             except (TypeError, ValidationError) as e:
                 errors.append(e)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,5 +4,5 @@ target-version = ['py36', 'py37', 'py38']
 
 [tool.pytest.ini_options]
 filterwarnings = [
-    "error",
+    "error:::marshmallow_dataclass|test",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 88
-target-version = ['py36', 'py37', 'py38']
+target-version = ['py36', 'py37', 'py38', 'py39', 'py310']
 
 [tool.pytest.ini_options]
 filterwarnings = [

--- a/tests/test_mypy.yml
+++ b/tests/test_mypy.yml
@@ -5,6 +5,8 @@
   mypy_config: |
     follow_imports = silent
     plugins = marshmallow_dataclass.mypy
+  env:
+    - PYTHONPATH=.
   main: |
     from dataclasses import dataclass
     import marshmallow as ma
@@ -28,6 +30,8 @@
   mypy_config: |
     follow_imports = silent
     plugins = marshmallow_dataclass.mypy
+  env:
+    - PYTHONPATH=.
   main: |
     from marshmallow_dataclass import dataclass
 
@@ -41,6 +45,8 @@
   mypy_config: |
     follow_imports = silent
     plugins = marshmallow_dataclass.mypy
+  env:
+    - PYTHONPATH=.
   main: |
     from dataclasses import dataclass
     import marshmallow


### PR DESCRIPTION
(This PR in an alternative to #209 and also includes #207.)

## Main Changes

### Explicitly add pytest’s rootdir to ~~MYPY~~PYTHONPATH in our mypy tests.

This helps mypy find marshmallow_dataclass when it is installed in editable mode.  (Ref #209, #207.)

### Do not fail tests upon warnings from external dependencies

We were configuring pytest with `-W error`.  This means tests failed if any warning was emitted by any dependency.
(E.g. `marshmallow<3.15` elicits a warning from its use of `distutils`.)

Here we update the warning filter so that we only fail on warnings from `marshmallow_dataclass` or our tests.

Other warnings will still be reported by `pytest` but will not cause our tests to fail.

----
## Other Changes

In order to get the CI tests to pass, we also cherry-pick PR #207 from @vit-zikmund

To get pre-commit checks to pass, we update the type of the second parameter to `Union._serialize`
to match [changes made](https://github.com/marshmallow-code/marshmallow/commit/2de97bc97891f88a56653fd583fe3635830afa2a) to `Field._serialize` typing in marshmallow 3.18.0.
(This keeps the pre-commit mypy check from failing due to "Liskov substitution principle" violation.)

Finally, we update the --target-version config for black (though I'm not sure that this makes any practical difference.)