### PR TITLE
Fix test for python 3.11

### DIFF
--- a/tests/test_class_schema.py
+++ b/tests/test_class_schema.py
@@ -227,7 +227,7 @@ class TestClassSchema(unittest.TestCase):
                 schema.load({"data": data})
 
     def test_final_infers_type_from_default(self):
-        # @dataclasses.dataclass
+        # @dataclasses.dataclass(frozen=True)
         class A:
             data: Final = "a"
 
@@ -238,7 +238,8 @@ class TestClassSchema(unittest.TestCase):
         # NOTE: This workaround is needed to avoid a Mypy crash.
         # See: https://github.com/python/mypy/issues/10090#issuecomment-865971891
         if not TYPE_CHECKING:
-            A = dataclasses.dataclass(A)
+            frozen_dataclass = dataclasses.dataclass(frozen=True)
+            A = frozen_dataclass(A)
             B = dataclasses.dataclass(B)
 
         with self.assertWarns(Warning):


### PR DESCRIPTION
Python’s `dataclasses.dataclass` tries to check that default values for dataclass attributes are immutable. A `ValueError`  ("mutable default is not allowed: use default_factory") is thrown when `dataclass` detects a mutable default value.
The way the check for "mutability" is performed [has changed][changed] in python 3.11, and it causes one of our tests to fail.

In our [test_final_infers_type_from_default][test] test, we use a dataclass instance as a default value.
Dataclasses, by default, are mutable, however, prior to python 3.11 we managed to sneak by the dataclass heuristic check for "mutability".  As of python 3.11, dataclass checks for hashability as a proxy for immutability.  Normal dataclasses, being mutable, are not hashable, so now we're in trouble.

Here we mark our test dataclasses as _frozen_ (so that they are immutable and hashable.)

[test]: https://github.com/lovasoa/marshmallow_dataclass/blob/32299c858c40b659ebbf3a7c8802b66b05d74aaf/tests/test_class_schema.py#L229
[changed]: https://github.com/python/cpython/commit/e029c53e1a408b89a4e3edf30a9b38b094f9c880