### PR TITLE
Add .load_to_mapping method to base schema

### DIFF
--- a/tests/test_load_to_mapping.py
+++ b/tests/test_load_to_mapping.py
@@ -1,0 +1,47 @@
+import dataclasses
+import unittest
+
+from marshmallow_dataclass import class_schema
+
+
+class Test_Schema_load_to_mapping(unittest.TestCase):
+    def test_simple(self):
+        @dataclasses.dataclass
+        class Simple:
+            one: int = dataclasses.field()
+            two: str = dataclasses.field()
+
+        simple_schema = class_schema(Simple)()
+        assert simple_schema.load_to_mapping({"one": "1", "two": "b"}) == {
+            "one": 1,
+            "two": "b",
+        }
+
+    def test_partial(self):
+        @dataclasses.dataclass
+        class Simple:
+            one: int = dataclasses.field()
+            two: str = dataclasses.field()
+
+        simple_schema = class_schema(Simple)()
+        assert simple_schema.load_to_mapping({"one": "1"}, partial=True) == {"one": 1}
+
+    def test_nested(self):
+        @dataclasses.dataclass
+        class Simple:
+            one: int = dataclasses.field()
+            two: str = dataclasses.field()
+
+        @dataclasses.dataclass
+        class Nested:
+            x: str = dataclasses.field()
+            child: Simple = dataclasses.field()
+
+        nested_schema = class_schema(Nested)()
+        assert nested_schema.load_to_mapping({"child": {"one": "1"}}, partial=True) == {
+            "child": {"one": 1},
+        }
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Following up on [this suggestion] made in a comment on #169 (see also #210), this provides a new schema method, `.load_to_mapping`, that essentially does a raw `marshmallow.Schema.load` without converting any of the deserialized values (either top-level or nested) to dataclasses.  The main point of this is to allow for deserializing partial data (with `partial=True`).

This PR is provided for discussion, as to:
- whether it's worthwhile
- whether there's a better name for the new method
- whether there's a better way to implement the new method
- ...

[this suggestion]: https://github.com/lovasoa/marshmallow_dataclass/issues/169#issuecomment-1256298997