### PR TITLE
Add support for Dict, List, set, frozenset, Tuple[T, ...], tuple[T, ...]

### DIFF
--- a/marshmallow_dataclass/__init__.py
+++ b/marshmallow_dataclass/__init__.py
@@ -470,17 +470,17 @@ def _field_by_supertype(
 
 def _generic_type_add_any(typ: type) -> type:
     """if typ is generic type without arguments, replace them by Any."""
-    if typ is list:
+    if typ is list or typ is List:
         typ = List[Any]
-    elif typ is dict:
+    elif typ is dict or typ is Dict:
         typ = Dict[Any, Any]
     elif typ is Mapping:
         typ = Mapping[Any, Any]
     elif typ is Sequence:
         typ = Sequence[Any]
-    elif typ is Set:
+    elif typ is set or typ is Set:
         typ = Set[Any]
-    elif typ is FrozenSet:
+    elif typ is frozenset or typ is FrozenSet:
         typ = FrozenSet[Any]
     return typ
 

--- a/marshmallow_dataclass/__init__.py
+++ b/marshmallow_dataclass/__init__.py
@@ -509,7 +509,11 @@ def _field_for_generic_type(
                 type_mapping.get(List, marshmallow.fields.List),
             )
             return list_type(child_type, **metadata)
-        if origin in (collections.abc.Sequence, Sequence):
+        if origin in (collections.abc.Sequence, Sequence) or (
+            origin in (tuple, Tuple)
+            and len(arguments) == 2
+            and arguments[1] is Ellipsis
+        ):
             from . import collection_field
 
             child_type = field_for_schema(

--- a/tests/test_field_for_schema.py
+++ b/tests/test_field_for_schema.py
@@ -1,4 +1,5 @@
 import inspect
+import sys
 import typing
 import unittest
 from enum import Enum
@@ -242,12 +243,32 @@ class TestFieldForSchema(unittest.TestCase):
         )
 
     def test_sequence(self):
+        self.maxDiff = 2000
+        self.assertFieldsEqual(
+            field_for_schema(typing.Sequence[int]),
+            collection_field.Sequence(fields.Integer(required=True), required=True),
+        )
+
+    def test_sequence_wo_args(self):
         self.assertFieldsEqual(
             field_for_schema(typing.Sequence),
             collection_field.Sequence(
                 cls_or_instance=fields.Raw(required=True, allow_none=True),
                 required=True,
             ),
+        )
+
+    def test_homogeneous_tuple_from_typing(self):
+        self.assertFieldsEqual(
+            field_for_schema(Tuple[str, ...]),
+            collection_field.Sequence(fields.String(required=True), required=True),
+        )
+
+    @unittest.skipIf(sys.version_info < (3, 9), "PEP 585 unsupported")
+    def test_homogeneous_tuple(self):
+        self.assertFieldsEqual(
+            field_for_schema(tuple[float, ...]),
+            collection_field.Sequence(fields.Float(required=True), required=True),
         )
 
     def test_set_from_typing(self):

--- a/tests/test_field_for_schema.py
+++ b/tests/test_field_for_schema.py
@@ -53,12 +53,37 @@ class TestFieldForSchema(unittest.TestCase):
             ),
         )
 
+    def test_dict_from_typing_wo_args(self):
+        self.assertFieldsEqual(
+            field_for_schema(Dict),
+            fields.Dict(
+                keys=fields.Raw(required=True, allow_none=True),
+                values=fields.Raw(required=True, allow_none=True),
+                required=True,
+            ),
+        )
+
     def test_builtin_dict(self):
         self.assertFieldsEqual(
             field_for_schema(dict),
             fields.Dict(
                 keys=fields.Raw(required=True, allow_none=True),
                 values=fields.Raw(required=True, allow_none=True),
+                required=True,
+            ),
+        )
+
+    def test_list_from_typing(self):
+        self.assertFieldsEqual(
+            field_for_schema(List[int]),
+            fields.List(fields.Integer(required=True), required=True),
+        )
+
+    def test_list_from_typing_wo_args(self):
+        self.assertFieldsEqual(
+            field_for_schema(List),
+            fields.List(
+                fields.Raw(required=True, allow_none=True),
                 required=True,
             ),
         )
@@ -225,7 +250,17 @@ class TestFieldForSchema(unittest.TestCase):
             ),
         )
 
-    def test_set(self):
+    def test_set_from_typing(self):
+        self.assertFieldsEqual(
+            field_for_schema(typing.Set[str]),
+            collection_field.Set(
+                fields.String(required=True),
+                frozen=False,
+                required=True,
+            ),
+        )
+
+    def test_set_from_typing_wo_args(self):
         self.assertFieldsEqual(
             field_for_schema(typing.Set),
             collection_field.Set(
@@ -235,9 +270,39 @@ class TestFieldForSchema(unittest.TestCase):
             ),
         )
 
-    def test_frozenset(self):
+    def test_builtin_set(self):
+        self.assertFieldsEqual(
+            field_for_schema(set),
+            collection_field.Set(
+                cls_or_instance=fields.Raw(required=True, allow_none=True),
+                frozen=False,
+                required=True,
+            ),
+        )
+
+    def test_frozenset_from_typing(self):
+        self.assertFieldsEqual(
+            field_for_schema(typing.FrozenSet[int]),
+            collection_field.Set(
+                fields.Integer(required=True),
+                frozen=True,
+                required=True,
+            ),
+        )
+
+    def test_frozenset_from_typing_wo_args(self):
         self.assertFieldsEqual(
             field_for_schema(typing.FrozenSet),
+            collection_field.Set(
+                cls_or_instance=fields.Raw(required=True, allow_none=True),
+                frozen=True,
+                required=True,
+            ),
+        )
+
+    def test_builtin_frozenset(self):
+        self.assertFieldsEqual(
+            field_for_schema(frozenset),
             collection_field.Set(
                 cls_or_instance=fields.Raw(required=True, allow_none=True),
                 frozen=True,


### PR DESCRIPTION
We already support a parameterless `dict` (which we treat equivalently to `Dict[Any, Any]`).  This PR adds support for a parameterless `Dict` as well.  (See #181).

Similarly, this adds support for `List`.

We also add support for the builtin `set` and `frozenset`.  (We already supported `Set` and `FrozenSet`.)

----

In addition, this PR adds support for homogeneous tuples notated as `Tuple[T, ...]` (or `tuple[T, ...]` for python 3.9 and above.)
We currently support homogeneous tuples only through the notation `Sequence[T]`.  (It seems generally more correct to me to use concrete rather than abstract types in dataclass declarations — though perhaps arguments could be made either way.)
