### PR TITLE
Fix and update pre-commit tests

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -10,6 +10,7 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python_version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "pypy3.9"]
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/asottile/pyupgrade
-  rev: v3.2.0
+  rev: v3.2.3
   hooks:
   - id: pyupgrade
     args: ["--py36-plus"]
@@ -10,12 +10,13 @@ repos:
   - id: black
     language_version: python3
 - repo: https://github.com/PyCQA/flake8
+  # Flake8==6.0.0 requires python>=3.8.1
   rev: 5.0.4
   hooks:
   - id: flake8
     additional_dependencies: ['flake8-bugbear==22.10.27']
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.982
+  rev: v0.991
   hooks:
   - id: mypy
     additional_dependencies: [marshmallow-enum,typeguard,marshmallow]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
   hooks:
   - id: black
     language_version: python3
-- repo: https://gitlab.com/pycqa/flake8
+- repo: https://github.com/PyCQA/flake8
   rev: 5.0.4
   hooks:
   - id: flake8

--- a/marshmallow_dataclass/__init__.py
+++ b/marshmallow_dataclass/__init__.py
@@ -116,7 +116,7 @@ def dataclass(
 # underscore.  The presence of _cls is used to detect if this
 # decorator is being called with parameters or not.
 def dataclass(
-    _cls: Type[_U] = None,
+    _cls: Optional[Type[_U]] = None,
     *,
     repr: bool = True,
     eq: bool = True,
@@ -173,7 +173,7 @@ def add_schema(_cls: Type[_U]) -> Type[_U]:
 
 @overload
 def add_schema(
-    base_schema: Type[marshmallow.Schema] = None,
+    base_schema: Optional[Type[marshmallow.Schema]] = None,
 ) -> Callable[[Type[_U]], Type[_U]]:
     ...
 
@@ -181,8 +181,8 @@ def add_schema(
 @overload
 def add_schema(
     _cls: Type[_U],
-    base_schema: Type[marshmallow.Schema] = None,
-    cls_frame: types.FrameType = None,
+    base_schema: Optional[Type[marshmallow.Schema]] = None,
+    cls_frame: Optional[types.FrameType] = None,
 ) -> Type[_U]:
     ...
 
@@ -224,7 +224,7 @@ def add_schema(_cls=None, base_schema=None, cls_frame=None):
 def class_schema(
     clazz: type,
     base_schema: Optional[Type[marshmallow.Schema]] = None,
-    clazz_frame: types.FrameType = None,
+    clazz_frame: Optional[types.FrameType] = None,
 ) -> Type[marshmallow.Schema]:
     """
     Convert a class to a marshmallow schema
@@ -363,7 +363,7 @@ def class_schema(
 def _internal_class_schema(
     clazz: type,
     base_schema: Optional[Type[marshmallow.Schema]] = None,
-    clazz_frame: types.FrameType = None,
+    clazz_frame: Optional[types.FrameType] = None,
 ) -> Type[marshmallow.Schema]:
     _RECURSION_GUARD.seen_classes[clazz] = clazz.__name__
     try:
@@ -599,7 +599,7 @@ def _field_for_generic_type(
 def field_for_schema(
     typ: type,
     default=marshmallow.missing,
-    metadata: Mapping[str, Any] = None,
+    metadata: Optional[Mapping[str, Any]] = None,
     base_schema: Optional[Type[marshmallow.Schema]] = None,
     typ_frame: Optional[types.FrameType] = None,
 ) -> marshmallow.fields.Field:
@@ -748,7 +748,7 @@ def _base_schema(
     # Remove `type: ignore` when mypy handles dynamic base classes
     # https://github.com/python/mypy/issues/2813
     class BaseSchema(base_schema or marshmallow.Schema):  # type: ignore
-        def load(self, data: Mapping, *, many: bool = None, **kwargs):
+        def load(self, data: Mapping, *, many: Optional[bool] = None, **kwargs):
             all_loaded = super().load(data, many=many, **kwargs)
             many = self.many if many is None else bool(many)
             if many:

--- a/marshmallow_dataclass/lazy_class_attribute.py
+++ b/marshmallow_dataclass/lazy_class_attribute.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable
+from typing import Any, Callable, Optional
 
 
 __all__ = ("lazy_class_attribute",)
@@ -13,7 +13,10 @@ class LazyClassAttribute:
     __slots__ = ("func", "name", "called", "forward_value")
 
     def __init__(
-        self, func: Callable[..., Any], name: str = None, forward_value: Any = None
+        self,
+        func: Callable[..., Any],
+        name: Optional[str] = None,
+        forward_value: Any = None,
     ):
         self.func = func
         self.name = name

--- a/tests/test_class_schema.py
+++ b/tests/test_class_schema.py
@@ -7,7 +7,7 @@ from uuid import UUID
 try:
     from typing import Final, Literal  # type: ignore[attr-defined]
 except ImportError:
-    from typing_extensions import Final, Literal  # type: ignore[misc]
+    from typing_extensions import Final, Literal  # type: ignore[assignment]
 
 import dataclasses
 from marshmallow import Schema, ValidationError

--- a/tests/test_field_for_schema.py
+++ b/tests/test_field_for_schema.py
@@ -8,7 +8,7 @@ from typing import Dict, Optional, Union, Any, List, Tuple
 try:
     from typing import Final, Literal  # type: ignore[attr-defined]
 except ImportError:
-    from typing_extensions import Final, Literal  # type: ignore[misc]
+    from typing_extensions import Final, Literal  # type: ignore[assignment]
 
 from marshmallow import fields, Schema, validate
 


### PR DESCRIPTION
The pre-commit tests broked as a result of flake8 [shutting down their old gitlab repository](https://www.reddit.com/r/Python/comments/yvfww8/flake8_took_down_the_gitlab_repository_in_favor/).

The PR fixes that, and also updates other pre-commit hooks to the latest versions.

We also disable the default `fail-fast` behavior for the python test workflow.  Even if the tests fail for one python version, we'd like to know whether they pass for other python versions. 