### PR TITLE
Add Meta option to include non init-ed fields

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python_version: ["3.7", "3.8", "3.9", "3.10", "3.11", "pypy3.9"]
+        python_version: ["3.7", "3.8", "3.9", "3.10", "3.11", "pypy3.10"]
         include:
           - os: "ubuntu-20.04"
             python_version: "3.6"

--- a/tests/test_class_schema.py
+++ b/tests/test_class_schema.py
@@ -434,6 +434,29 @@ class TestClassSchema(unittest.TestCase):
             {"first": {"second": {"first": None}}},
         )
 
+    def test_init_fields(self):
+        @dataclasses.dataclass
+        class NoMeta:
+            no_init: str = dataclasses.field(init=False)
+
+        @dataclasses.dataclass
+        class NoInit:
+            class Meta:
+                pass
+
+            no_init: str = dataclasses.field(init=False)
+
+        @dataclasses.dataclass
+        class Init:
+            class Meta:
+                include_non_init = True
+
+            no_init: str = dataclasses.field(init=False)
+
+        self.assertNotIn("no_init", class_schema(NoMeta)().fields)
+        self.assertNotIn("no_init", class_schema(NoInit)().fields)
+        self.assertIn("no_init", class_schema(Init)().fields)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_field_for_schema.py
+++ b/tests/test_field_for_schema.py
@@ -185,8 +185,8 @@ class TestFieldForSchema(unittest.TestCase):
             field_for_schema(Optional[Union[int, str]]),
             union_field.Union(
                 [
-                    (int, fields.Integer(required=True)),
                     (str, fields.String(required=True)),
+                    (int, fields.Integer(required=True)),
                 ],
                 required=False,
                 dump_default=None,

--- a/tests/test_field_for_schema.py
+++ b/tests/test_field_for_schema.py
@@ -156,6 +156,10 @@ class TestFieldForSchema(unittest.TestCase):
             field_for_schema(Final), fields.Raw(required=True, allow_none=True)
         )
 
+    @unittest.skipIf(
+        sys.version_info < (3, 7),
+        "union ordering is not guaranteed in python < 3.7",
+    )
     def test_union(self):
         self.assertFieldsEqual(
             field_for_schema(Union[int, str]),

--- a/tests/test_field_for_schema.py
+++ b/tests/test_field_for_schema.py
@@ -26,11 +26,18 @@ class TestFieldForSchema(unittest.TestCase):
     def assertFieldsEqual(self, a: fields.Field, b: fields.Field):
         self.assertEqual(a.__class__, b.__class__, "field class")
 
+        def canonical(k, v):
+            if k == "union_fields":
+                # See https://github.com/lovasoa/marshmallow_dataclass/pull/246#issuecomment-1722291806
+                return k, sorted(map(repr, v))
+            elif inspect.isclass(v):
+                return k, f"{v!r} ({v.__mro__!r})"
+            else:
+                return k, repr(v)
+
         def attrs(x):
             return sorted(
-                (k, f"{v!r} ({v.__mro__!r})" if inspect.isclass(v) else repr(v))
-                for k, v in x.__dict__.items()
-                if not k.startswith("_")
+                canonical(k, v) for k, v in vars(x).items() if not k.startswith("_")
             )
 
         self.assertEqual(attrs(a), attrs(b))

--- a/tests/test_field_for_schema.py
+++ b/tests/test_field_for_schema.py
@@ -25,11 +25,11 @@ class TestFieldForSchema(unittest.TestCase):
         self.assertEqual(a.__class__, b.__class__, "field class")
 
         def attrs(x):
-            return {
-                k: f"{v!r} ({v.__mro__!r})" if inspect.isclass(v) else repr(v)
+            return sorted(
+                (k, f"{v!r} ({v.__mro__!r})" if inspect.isclass(v) else repr(v))
                 for k, v in x.__dict__.items()
                 if not k.startswith("_")
-            }
+            )
 
         self.assertEqual(attrs(a), attrs(b))
 

--- a/tests/test_field_for_schema.py
+++ b/tests/test_field_for_schema.py
@@ -21,6 +21,8 @@ from marshmallow_dataclass import (
 
 
 class TestFieldForSchema(unittest.TestCase):
+    maxDiff = None
+
     def assertFieldsEqual(self, a: fields.Field, b: fields.Field):
         self.assertEqual(a.__class__, b.__class__, "field class")
 

--- a/tests/test_field_for_schema.py
+++ b/tests/test_field_for_schema.py
@@ -156,10 +156,6 @@ class TestFieldForSchema(unittest.TestCase):
             field_for_schema(Final), fields.Raw(required=True, allow_none=True)
         )
 
-    @unittest.skipIf(
-        sys.version_info < (3, 7),
-        "union ordering is not guaranteed in python < 3.7",
-    )
     def test_union(self):
         self.assertFieldsEqual(
             field_for_schema(Union[int, str]),

--- a/tests/test_field_for_schema.py
+++ b/tests/test_field_for_schema.py
@@ -187,8 +187,8 @@ class TestFieldForSchema(unittest.TestCase):
             field_for_schema(Optional[Union[int, str]]),
             union_field.Union(
                 [
-                    (str, fields.String(required=True)),
                     (int, fields.Integer(required=True)),
+                    (str, fields.String(required=True)),
                 ],
                 required=False,
                 dump_default=None,

--- a/tests/test_mypy.yml
+++ b/tests/test_mypy.yml
@@ -6,6 +6,7 @@
     follow_imports = silent
     plugins = marshmallow_dataclass.mypy
     show_error_codes = true
+    python_version = 3.6
   env:
     - PYTHONPATH=.
   main: |


### PR DESCRIPTION
Updates #60

This adds the ability to include non init-ed fields into the schema by using a new Meta option , `include_non_init`.

I don't think it's the best way to address #60, but it is a very small code change to get the functionality working.