### PR TITLE
Do not ignore Union argument ordering in tests

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -47,4 +47,4 @@ jobs:
       if: ${{ matrix.python_version != 'pypy3' && matrix.python_version != '3.6' }}
       run: pre-commit run --all-files
     - name: Test with pytest
-      run: pytest
+      run: pytest -ra

--- a/tests/test_field_for_schema.py
+++ b/tests/test_field_for_schema.py
@@ -202,6 +202,7 @@ class TestFieldForSchema(unittest.TestCase):
         )
 
     def test_optional_multiple_types_ignoring_union_field_order(self):
+        # see https://github.com/lovasoa/marshmallow_dataclass/pull/246#issuecomment-1722204048
         result = field_for_schema(Optional[Union[int, str]])
         expected = union_field.Union(
             [

--- a/tests/test_field_for_schema.py
+++ b/tests/test_field_for_schema.py
@@ -26,18 +26,11 @@ class TestFieldForSchema(unittest.TestCase):
     def assertFieldsEqual(self, a: fields.Field, b: fields.Field):
         self.assertEqual(a.__class__, b.__class__, "field class")
 
-        def canonical(k, v):
-            if k == "union_fields":
-                # See https://github.com/lovasoa/marshmallow_dataclass/pull/246#issuecomment-1722291806
-                return k, sorted(map(repr, v))
-            elif inspect.isclass(v):
-                return k, f"{v!r} ({v.__mro__!r})"
-            else:
-                return k, repr(v)
-
         def attrs(x):
             return sorted(
-                canonical(k, v) for k, v in vars(x).items() if not k.startswith("_")
+                (k, f"{v!r} ({v.__mro__!r})" if inspect.isclass(v) else repr(v))
+                for k, v in x.__dict__.items()
+                if not k.startswith("_")
             )
 
         self.assertEqual(attrs(a), attrs(b))


### PR DESCRIPTION
The union argument ordering is important!

What's here:
- Revert b61cd5035b7ec0722e1ac7a361cbd9e8f6a4387a. That commit effectively hides failing tests by ignoring the argument order of union fields.
- The one test that fails because of that reversion is marked an expected failure.
- A new version of that failing test is added.  The new version does ignore the union argument ordering (and so is expected to pass).


### Related

The failing test fails due to #247.

This was discussed in [PR #246](https://github.com/lovasoa/marshmallow_dataclass/pull/246#issuecomment-1722295574).
