### PR TITLE
docs/class_schema: fix formatting

### DIFF
--- a/marshmallow_dataclass/__init__.py
+++ b/marshmallow_dataclass/__init__.py
@@ -300,6 +300,7 @@ def class_schema(
     Marking dataclass fields as non-initialized (``init=False``), by default, will result in those
     fields from being exluded in the schema. To override this behaviour, set the ``Meta`` option
     ``include_non_init=True``.
+
     >>> @dataclasses.dataclass()
     ... class C:
     ...   important: int = dataclasses.field(init=True, default=0)


### PR DESCRIPTION
Accidentally missed a newline when adding the new feature in #246

Currently looks like 🙈 
![image](https://github.com/lovasoa/marshmallow_dataclass/assets/5251487/56cbea57-1ad1-4e65-81c9-65ffa648eb89)
