### PR TITLE
Add Generic dataclasses

### DIFF
--- a/marshmallow_dataclass/__init__.py
+++ b/marshmallow_dataclass/__init__.py
@@ -374,7 +374,9 @@ def class_schema(
     >>> class_schema(Custom)().load({})
     Custom(name=None)
     """
-    if not dataclasses.is_dataclass(clazz):
+    if not dataclasses.is_dataclass(clazz) and not _is_generic_alias_of_dataclass(
+        clazz
+    ):
         clazz = dataclasses.dataclass(clazz)
     if not clazz_frame:
         current_frame = inspect.currentframe()
@@ -397,8 +399,7 @@ def _internal_class_schema(
 ) -> Type[marshmallow.Schema]:
     _RECURSION_GUARD.seen_classes[clazz] = clazz.__name__
     try:
-        # noinspection PyDataclass
-        fields: Tuple[dataclasses.Field, ...] = dataclasses.fields(clazz)
+        class_name, fields = _dataclass_name_and_fields(clazz)
     except TypeError:  # Not a dataclass
         try:
             warnings.warn(
@@ -448,7 +449,7 @@ def _internal_class_schema(
         if field.init or include_non_init
     )
 
-    schema_class = type(clazz.__name__, (_base_schema(clazz, base_schema),), attributes)
+    schema_class = type(class_name, (_base_schema(clazz, base_schema),), attributes)
     return cast(Type[marshmallow.Schema], schema_class)
 
 
@@ -810,6 +811,47 @@ def _get_field_default(field: dataclasses.Field):
     elif field.default is dataclasses.MISSING:
         return marshmallow.missing
     return field.default
+
+
+def _is_generic_alias_of_dataclass(clazz: type) -> bool:
+    """
+    Check if given class is a generic alias of a dataclass, if the dataclass is
+    defined as `class A(Generic[T])`, this method will return true if `A[int]` is passed
+    """
+    return typing_inspect.is_generic_type(clazz) and dataclasses.is_dataclass(
+        typing_inspect.get_origin(clazz)
+    )
+
+
+# noinspection PyDataclass
+def _dataclass_name_and_fields(
+    clazz: type,
+) -> Tuple[str, Tuple[dataclasses.Field, ...]]:
+    if not _is_generic_alias_of_dataclass(clazz):
+        return clazz.__name__, dataclasses.fields(clazz)
+
+    base_dataclass = typing_inspect.get_origin(clazz)
+    base_parameters = typing_inspect.get_parameters(base_dataclass)
+    type_arguments = typing_inspect.get_args(clazz)
+    params_to_args = dict(zip(base_parameters, type_arguments))
+    non_generic_fields = [  # swap generic typed fields with types in given type arguments
+        (
+            f.name,
+            params_to_args.get(f.type, f.type),
+            dataclasses.field(
+                default=f.default,
+                # ignoring mypy: https://github.com/python/mypy/issues/6910
+                default_factory=f.default_factory,  # type: ignore
+                init=f.init,
+                metadata=f.metadata,
+            ),
+        )
+        for f in dataclasses.fields(base_dataclass)
+    ]
+    non_generic_dataclass = dataclasses.make_dataclass(
+        cls_name=f"{base_dataclass.__name__}{type_arguments}", fields=non_generic_fields
+    )
+    return base_dataclass.__name__, dataclasses.fields(non_generic_dataclass)
 
 
 def NewType(

--- a/marshmallow_dataclass/__init__.py
+++ b/marshmallow_dataclass/__init__.py
@@ -34,6 +34,7 @@ Full example::
       })
       Schema: ClassVar[Type[Schema]] = Schema # For the type checker
 """
+
 import collections.abc
 import dataclasses
 import inspect
@@ -43,14 +44,11 @@ import types
 import warnings
 from enum import Enum
 from functools import lru_cache, partial
+from typing import Any, Callable, Dict, FrozenSet, List, Mapping
+from typing import NewType as typing_NewType
 from typing import (
-    Any,
-    Callable,
-    Dict,
-    List,
-    Mapping,
-    NewType as typing_NewType,
     Optional,
+    Sequence,
     Set,
     Tuple,
     Type,
@@ -59,15 +57,12 @@ from typing import (
     cast,
     get_type_hints,
     overload,
-    Sequence,
-    FrozenSet,
 )
 
 import marshmallow
 import typing_inspect
 
 from marshmallow_dataclass.lazy_class_attribute import lazy_class_attribute
-
 
 if sys.version_info >= (3, 11):
     from typing import dataclass_transform
@@ -105,8 +100,7 @@ def dataclass(
     frozen: bool = False,
     base_schema: Optional[Type[marshmallow.Schema]] = None,
     cls_frame: Optional[types.FrameType] = None,
-) -> Type[_U]:
-    ...
+) -> Type[_U]: ...
 
 
 @overload
@@ -119,8 +113,7 @@ def dataclass(
     frozen: bool = False,
     base_schema: Optional[Type[marshmallow.Schema]] = None,
     cls_frame: Optional[types.FrameType] = None,
-) -> Callable[[Type[_U]], Type[_U]]:
-    ...
+) -> Callable[[Type[_U]], Type[_U]]: ...
 
 
 # _cls should never be specified by keyword, so start it with an
@@ -179,15 +172,13 @@ def dataclass(
 
 
 @overload
-def add_schema(_cls: Type[_U]) -> Type[_U]:
-    ...
+def add_schema(_cls: Type[_U]) -> Type[_U]: ...
 
 
 @overload
 def add_schema(
     base_schema: Optional[Type[marshmallow.Schema]] = None,
-) -> Callable[[Type[_U]], Type[_U]]:
-    ...
+) -> Callable[[Type[_U]], Type[_U]]: ...
 
 
 @overload
@@ -195,8 +186,7 @@ def add_schema(
     _cls: Type[_U],
     base_schema: Optional[Type[marshmallow.Schema]] = None,
     cls_frame: Optional[types.FrameType] = None,
-) -> Type[_U]:
-    ...
+) -> Type[_U]: ...
 
 
 def add_schema(_cls=None, base_schema=None, cls_frame=None):
@@ -386,9 +376,15 @@ def class_schema(
         del current_frame
     _RECURSION_GUARD.seen_classes = {}
     try:
-        return _internal_class_schema(clazz, base_schema, clazz_frame)
+        return _internal_class_schema(clazz, base_schema, clazz_frame, None)
     finally:
         _RECURSION_GUARD.seen_classes.clear()
+
+
+def _dataclass_fields(clazz: type) -> Tuple[dataclasses.Field, ...]:
+    if _is_generic_alias_of_dataclass(clazz):
+        clazz = typing_inspect.get_origin(clazz)
+    return dataclasses.fields(clazz)
 
 
 @lru_cache(maxsize=MAX_CLASS_SCHEMA_CACHE_SIZE)
@@ -396,10 +392,11 @@ def _internal_class_schema(
     clazz: type,
     base_schema: Optional[Type[marshmallow.Schema]] = None,
     clazz_frame: Optional[types.FrameType] = None,
+    generic_params_to_args: Optional[Tuple[Tuple[type, type], ...]] = None,
 ) -> Type[marshmallow.Schema]:
     _RECURSION_GUARD.seen_classes[clazz] = clazz.__name__
     try:
-        class_name, fields = _dataclass_name_and_fields(clazz)
+        fields = _dataclass_fields(clazz)
     except TypeError:  # Not a dataclass
         try:
             warnings.warn(
@@ -414,7 +411,9 @@ def _internal_class_schema(
                 "****** WARNING ******"
             )
             created_dataclass: type = dataclasses.dataclass(clazz)
-            return _internal_class_schema(created_dataclass, base_schema, clazz_frame)
+            return _internal_class_schema(
+                created_dataclass, base_schema, clazz_frame, generic_params_to_args
+            )
         except Exception as exc:
             raise TypeError(
                 f"{getattr(clazz, '__name__', repr(clazz))} is not a dataclass and cannot be turned into one."
@@ -430,10 +429,11 @@ def _internal_class_schema(
     # Determine whether we should include non-init fields
     include_non_init = getattr(getattr(clazz, "Meta", None), "include_non_init", False)
 
+    if _is_generic_alias_of_dataclass(clazz) and generic_params_to_args is None:
+        generic_params_to_args = _generic_params_to_args(clazz)
+
+    type_hints = _dataclass_type_hints(clazz, clazz_frame, generic_params_to_args)
     # Update the schema members to contain marshmallow fields instead of dataclass fields
-    type_hints = get_type_hints(
-        clazz, localns=clazz_frame.f_locals if clazz_frame else None
-    )
     attributes.update(
         (
             field.name,
@@ -443,13 +443,14 @@ def _internal_class_schema(
                 field.metadata,
                 base_schema,
                 clazz_frame,
+                generic_params_to_args,
             ),
         )
         for field in fields
         if field.init or include_non_init
     )
 
-    schema_class = type(class_name, (_base_schema(clazz, base_schema),), attributes)
+    schema_class = type(clazz.__name__, (_base_schema(clazz, base_schema),), attributes)
     return cast(Type[marshmallow.Schema], schema_class)
 
 
@@ -584,7 +585,7 @@ def _field_for_generic_type(
                 ),
             )
             return tuple_type(children, **metadata)
-        elif origin in (dict, Dict, collections.abc.Mapping, Mapping):
+        if origin in (dict, Dict, collections.abc.Mapping, Mapping):
             dict_type = type_mapping.get(Dict, marshmallow.fields.Dict)
             return dict_type(
                 keys=field_for_schema(
@@ -636,6 +637,7 @@ def field_for_schema(
     metadata: Optional[Mapping[str, Any]] = None,
     base_schema: Optional[Type[marshmallow.Schema]] = None,
     typ_frame: Optional[types.FrameType] = None,
+    generic_params_to_args: Optional[Tuple[Tuple[type, type], ...]] = None,
 ) -> marshmallow.fields.Field:
     """
     Get a marshmallow Field corresponding to the given python type.
@@ -769,7 +771,7 @@ def field_for_schema(
         nested_schema
         or forward_reference
         or _RECURSION_GUARD.seen_classes.get(typ)
-        or _internal_class_schema(typ, base_schema, typ_frame)  # type: ignore [arg-type]
+        or _internal_class_schema(typ, base_schema, typ_frame, generic_params_to_args)  # type: ignore [arg-type]
     )
 
     return marshmallow.fields.Nested(nested, **metadata)
@@ -823,35 +825,33 @@ def _is_generic_alias_of_dataclass(clazz: type) -> bool:
     )
 
 
-# noinspection PyDataclass
-def _dataclass_name_and_fields(
-    clazz: type,
-) -> Tuple[str, Tuple[dataclasses.Field, ...]]:
-    if not _is_generic_alias_of_dataclass(clazz):
-        return clazz.__name__, dataclasses.fields(clazz)
-
+def _generic_params_to_args(clazz: type) -> Tuple[Tuple[type, type], ...]:
     base_dataclass = typing_inspect.get_origin(clazz)
     base_parameters = typing_inspect.get_parameters(base_dataclass)
     type_arguments = typing_inspect.get_args(clazz)
-    params_to_args = dict(zip(base_parameters, type_arguments))
-    non_generic_fields = [  # swap generic typed fields with types in given type arguments
-        (
-            f.name,
-            params_to_args.get(f.type, f.type),
-            dataclasses.field(
-                default=f.default,
-                # ignoring mypy: https://github.com/python/mypy/issues/6910
-                default_factory=f.default_factory,  # type: ignore
-                init=f.init,
-                metadata=f.metadata,
-            ),
-        )
-        for f in dataclasses.fields(base_dataclass)
-    ]
-    non_generic_dataclass = dataclasses.make_dataclass(
-        cls_name=f"{base_dataclass.__name__}{type_arguments}", fields=non_generic_fields
-    )
-    return base_dataclass.__name__, dataclasses.fields(non_generic_dataclass)
+    return tuple(zip(base_parameters, type_arguments))
+
+
+def _dataclass_type_hints(
+    clazz: type,
+    clazz_frame: types.FrameType = None,
+    generic_params_to_args: Optional[Tuple[Tuple[type, type], ...]] = None,
+) -> Mapping[str, type]:
+    localns = clazz_frame.f_locals if clazz_frame else None
+    if not _is_generic_alias_of_dataclass(clazz):
+        return get_type_hints(clazz, localns=localns)
+    # dataclass is generic
+    generic_type_hints = get_type_hints(typing_inspect.get_origin(clazz), localns)
+    generic_params_map = dict(generic_params_to_args if generic_params_to_args else {})
+
+    def _get_hint(_t: type) -> type:
+        if isinstance(_t, TypeVar):
+            return generic_params_map[_t]
+        return _t
+
+    return {
+        field_name: _get_hint(typ) for field_name, typ in generic_type_hints.items()
+    }
 
 
 def NewType(

--- a/marshmallow_dataclass/__init__.py
+++ b/marshmallow_dataclass/__init__.py
@@ -100,7 +100,8 @@ def dataclass(
     frozen: bool = False,
     base_schema: Optional[Type[marshmallow.Schema]] = None,
     cls_frame: Optional[types.FrameType] = None,
-) -> Type[_U]: ...
+) -> Type[_U]:
+    ...
 
 
 @overload
@@ -113,7 +114,8 @@ def dataclass(
     frozen: bool = False,
     base_schema: Optional[Type[marshmallow.Schema]] = None,
     cls_frame: Optional[types.FrameType] = None,
-) -> Callable[[Type[_U]], Type[_U]]: ...
+) -> Callable[[Type[_U]], Type[_U]]:
+    ...
 
 
 # _cls should never be specified by keyword, so start it with an
@@ -172,13 +174,15 @@ def dataclass(
 
 
 @overload
-def add_schema(_cls: Type[_U]) -> Type[_U]: ...
+def add_schema(_cls: Type[_U]) -> Type[_U]:
+    ...
 
 
 @overload
 def add_schema(
     base_schema: Optional[Type[marshmallow.Schema]] = None,
-) -> Callable[[Type[_U]], Type[_U]]: ...
+) -> Callable[[Type[_U]], Type[_U]]:
+    ...
 
 
 @overload
@@ -186,7 +190,8 @@ def add_schema(
     _cls: Type[_U],
     base_schema: Optional[Type[marshmallow.Schema]] = None,
     cls_frame: Optional[types.FrameType] = None,
-) -> Type[_U]: ...
+) -> Type[_U]:
+    ...
 
 
 def add_schema(_cls=None, base_schema=None, cls_frame=None):
@@ -805,7 +810,9 @@ def field_for_schema(
         nested_schema
         or forward_reference
         or _RECURSION_GUARD.seen_classes.get(typ)
-        or _internal_class_schema(typ, base_schema, typ_frame, generic_params_to_args)  # type: ignore [arg-type]
+        or _internal_class_schema(
+            typ, base_schema, typ_frame, generic_params_to_args  # type: ignore [arg-type]
+        )
     )
 
     return marshmallow.fields.Nested(nested, **metadata)
@@ -873,7 +880,7 @@ def _generic_params_to_args(clazz: type) -> Tuple[Tuple[type, type], ...]:
 
 def _dataclass_type_hints(
     clazz: type,
-    clazz_frame: types.FrameType = None,
+    clazz_frame: Optional[types.FrameType] = None,
     generic_params_to_args: Optional[Tuple[Tuple[type, type], ...]] = None,
 ) -> Mapping[str, type]:
     localns = clazz_frame.f_locals if clazz_frame else None

--- a/marshmallow_dataclass/__init__.py
+++ b/marshmallow_dataclass/__init__.py
@@ -854,8 +854,13 @@ def _is_generic_alias_of_dataclass(clazz: type) -> bool:
     Check if given class is a generic alias of a dataclass, if the dataclass is
     defined as `class A(Generic[T])`, this method will return true if `A[int]` is passed
     """
-    return typing_inspect.is_generic_type(clazz) and dataclasses.is_dataclass(
-        typing_inspect.get_origin(clazz)
+    is_generic = typing_inspect.is_generic_type(clazz)
+    type_arguments = typing_inspect.get_args(clazz)
+    origin_class = typing_inspect.get_origin(clazz)
+    return (
+        is_generic
+        and len(type_arguments) > 0
+        and dataclasses.is_dataclass(origin_class)
     )
 
 

--- a/marshmallow_dataclass/__init__.py
+++ b/marshmallow_dataclass/__init__.py
@@ -36,6 +36,7 @@ Full example::
 """
 
 import collections.abc
+import copy
 import dataclasses
 import inspect
 import sys
@@ -44,7 +45,7 @@ import types
 import warnings
 from enum import Enum
 from functools import lru_cache, partial
-from typing import Any, Callable, Dict, FrozenSet, List, Mapping
+from typing import Any, Callable, Dict, FrozenSet, Generic, List, Mapping
 from typing import NewType as typing_NewType
 from typing import (
     Optional,
@@ -87,6 +88,63 @@ MAX_CLASS_SCHEMA_CACHE_SIZE = 1024
 
 # Recursion guard for class_schema()
 _RECURSION_GUARD = threading.local()
+
+
+class UnboundTypeVarError(TypeError):
+    """TypeVar instance can not be resolved to a type spec.
+
+    This exception is raised when an unbound TypeVar is encountered.
+
+    """
+
+
+class InvalidStateError(Exception):
+    """Raised when an operation is performed on a future that is not
+    allowed in the current state.
+    """
+
+
+class _Future(Generic[_U]):
+    """The _Future class allows deferred access to a result that is not
+    yet available.
+    """
+
+    _done: bool
+    _result: _U
+
+    def __init__(self) -> None:
+        self._done = False
+
+    def done(self) -> bool:
+        """Return ``True`` if the value is available"""
+        return self._done
+
+    def result(self) -> _U:
+        """Return the deferred value.
+
+        Raises ``InvalidStateError`` if the value has not been set.
+        """
+        if self.done():
+            return self._result
+        raise InvalidStateError("result has not been set")
+
+    def set_result(self, result: _U) -> None:
+        if self.done():
+            raise InvalidStateError("result has already been set")
+        self._result = result
+        self._done = True
+
+
+def _check_decorated_type(cls: object) -> None:
+    if not isinstance(cls, type):
+        raise TypeError(f"expected a class not {cls!r}")
+    if _is_generic_alias(cls):
+        # A .Schema attribute doesn't make sense on a generic alias — there's
+        # no way for it to know the generic parameters at run time.
+        raise TypeError(
+            "decorator does not support generic aliasses "
+            "(hint: use class_schema directly instead)"
+        )
 
 
 @overload
@@ -158,6 +216,9 @@ def dataclass(
     >>> Point.Schema().load({'x':0, 'y':0}) # This line can be statically type checked
     Point(x=0.0, y=0.0)
     """
+    if _cls is not None:
+        _check_decorated_type(_cls)
+
     # dataclass's typing doesn't expect it to be called as a function, so ignore type check
     dc = dataclasses.dataclass(  # type: ignore
         _cls, repr=repr, eq=eq, order=order, unsafe_hash=unsafe_hash, frozen=frozen
@@ -217,6 +278,7 @@ def add_schema(_cls=None, base_schema=None, cls_frame=None):
     """
 
     def decorator(clazz: Type[_U]) -> Type[_U]:
+        _check_decorated_type(clazz)
         # noinspection PyTypeHints
         clazz.Schema = lazy_class_attribute(  # type: ignore
             partial(class_schema, clazz, base_schema, cls_frame),
@@ -381,15 +443,9 @@ def class_schema(
         del current_frame
     _RECURSION_GUARD.seen_classes = {}
     try:
-        return _internal_class_schema(clazz, base_schema, clazz_frame, None)
+        return _internal_class_schema(clazz, base_schema, clazz_frame)
     finally:
         _RECURSION_GUARD.seen_classes.clear()
-
-
-def _dataclass_fields(clazz: type) -> Tuple[dataclasses.Field, ...]:
-    if _is_generic_alias_of_dataclass(clazz):
-        clazz = typing_inspect.get_origin(clazz)
-    return dataclasses.fields(clazz)
 
 
 @lru_cache(maxsize=MAX_CLASS_SCHEMA_CACHE_SIZE)
@@ -397,7 +453,6 @@ def _internal_class_schema(
     clazz: type,
     base_schema: Optional[Type[marshmallow.Schema]] = None,
     clazz_frame: Optional[types.FrameType] = None,
-    generic_params_to_args: Optional[Tuple[Tuple[type, type], ...]] = None,
 ) -> Type[marshmallow.Schema]:
     # generic aliases do not have a __name__ prior python 3.10
     _name = getattr(clazz, "__name__", repr(clazz))
@@ -405,6 +460,8 @@ def _internal_class_schema(
     _RECURSION_GUARD.seen_classes[clazz] = _name
     try:
         fields = _dataclass_fields(clazz)
+    except UnboundTypeVarError:
+        raise
     except TypeError:  # Not a dataclass
         try:
             warnings.warn(
@@ -419,9 +476,9 @@ def _internal_class_schema(
                 "****** WARNING ******"
             )
             created_dataclass: type = dataclasses.dataclass(clazz)
-            return _internal_class_schema(
-                created_dataclass, base_schema, clazz_frame, generic_params_to_args
-            )
+            return _internal_class_schema(created_dataclass, base_schema, clazz_frame)
+        except UnboundTypeVarError:
+            raise
         except Exception as exc:
             raise TypeError(
                 f"{getattr(clazz, '__name__', repr(clazz))} is not a dataclass and cannot be turned into one."
@@ -436,22 +493,15 @@ def _internal_class_schema(
 
     # Determine whether we should include non-init fields
     include_non_init = getattr(getattr(clazz, "Meta", None), "include_non_init", False)
-
-    if _is_generic_alias_of_dataclass(clazz) and generic_params_to_args is None:
-        generic_params_to_args = _generic_params_to_args(clazz)
-
-    type_hints = _dataclass_type_hints(clazz, clazz_frame, generic_params_to_args)
-    # Update the schema members to contain marshmallow fields instead of dataclass fields
     attributes.update(
         (
             field.name,
             field_for_schema(
-                type_hints[field.name],
+                _get_field_type_hints(field, clazz_frame),
                 _get_field_default(field),
                 field.metadata,
                 base_schema,
                 clazz_frame,
-                generic_params_to_args,
             ),
         )
         for field in fields
@@ -477,7 +527,6 @@ def _field_by_supertype(
     metadata: dict,
     base_schema: Optional[Type[marshmallow.Schema]],
     typ_frame: Optional[types.FrameType],
-    generic_params_to_args: Optional[Tuple[Tuple[type, type], ...]] = None,
 ) -> marshmallow.fields.Field:
     """
     Return a new field for fields based on a super field. (Usually spawned from NewType)
@@ -509,7 +558,6 @@ def _field_by_supertype(
             default=default,
             base_schema=base_schema,
             typ_frame=typ_frame,
-            generic_params_to_args=generic_params_to_args,
         )
 
 
@@ -534,7 +582,6 @@ def _field_for_generic_type(
     typ: type,
     base_schema: Optional[Type[marshmallow.Schema]],
     typ_frame: Optional[types.FrameType],
-    generic_params_to_args: Optional[Tuple[Tuple[type, type], ...]] = None,
     **metadata: Any,
 ) -> Optional[marshmallow.fields.Field]:
     """
@@ -551,7 +598,6 @@ def _field_for_generic_type(
                 arguments[0],
                 base_schema=base_schema,
                 typ_frame=typ_frame,
-                generic_params_to_args=generic_params_to_args,
             )
             list_type = cast(
                 Type[marshmallow.fields.List],
@@ -569,7 +615,6 @@ def _field_for_generic_type(
                 arguments[0],
                 base_schema=base_schema,
                 typ_frame=typ_frame,
-                generic_params_to_args=generic_params_to_args,
             )
             return collection_field.Sequence(cls_or_instance=child_type, **metadata)
         if origin in (set, Set):
@@ -579,7 +624,6 @@ def _field_for_generic_type(
                 arguments[0],
                 base_schema=base_schema,
                 typ_frame=typ_frame,
-                generic_params_to_args=generic_params_to_args,
             )
             return collection_field.Set(
                 cls_or_instance=child_type, frozen=False, **metadata
@@ -591,7 +635,6 @@ def _field_for_generic_type(
                 arguments[0],
                 base_schema=base_schema,
                 typ_frame=typ_frame,
-                generic_params_to_args=generic_params_to_args,
             )
             return collection_field.Set(
                 cls_or_instance=child_type, frozen=True, **metadata
@@ -602,7 +645,6 @@ def _field_for_generic_type(
                     arg,
                     base_schema=base_schema,
                     typ_frame=typ_frame,
-                    generic_params_to_args=generic_params_to_args,
                 )
                 for arg in arguments
             )
@@ -620,13 +662,11 @@ def _field_for_generic_type(
                     arguments[0],
                     base_schema=base_schema,
                     typ_frame=typ_frame,
-                    generic_params_to_args=generic_params_to_args,
                 ),
                 values=field_for_schema(
                     arguments[1],
                     base_schema=base_schema,
                     typ_frame=typ_frame,
-                    generic_params_to_args=generic_params_to_args,
                 ),
                 **metadata,
             )
@@ -644,7 +684,6 @@ def _field_for_generic_type(
                 metadata=metadata,
                 base_schema=base_schema,
                 typ_frame=typ_frame,
-                generic_params_to_args=generic_params_to_args,
             )
         from . import union_field
 
@@ -657,7 +696,6 @@ def _field_for_generic_type(
                         metadata={"required": True},
                         base_schema=base_schema,
                         typ_frame=typ_frame,
-                        generic_params_to_args=generic_params_to_args,
                     ),
                 )
                 for subtyp in subtypes
@@ -673,7 +711,6 @@ def field_for_schema(
     metadata: Optional[Mapping[str, Any]] = None,
     base_schema: Optional[Type[marshmallow.Schema]] = None,
     typ_frame: Optional[types.FrameType] = None,
-    generic_params_to_args: Optional[Tuple[Tuple[type, type], ...]] = None,
 ) -> marshmallow.fields.Field:
     """
     Get a marshmallow Field corresponding to the given python type.
@@ -695,6 +732,9 @@ def field_for_schema(
     >>> field_for_schema(str, metadata={"marshmallow_field": marshmallow.fields.Url()}).__class__
     <class 'marshmallow.fields.Url'>
     """
+
+    if isinstance(typ, TypeVar):
+        raise UnboundTypeVarError(f"can not resolve type variable {typ.__name__}")
 
     metadata = {} if metadata is None else dict(metadata)
 
@@ -766,9 +806,7 @@ def field_for_schema(
                 )
         else:
             subtyp = Any
-        return field_for_schema(
-            subtyp, default, metadata, base_schema, typ_frame, generic_params_to_args
-        )
+        return field_for_schema(subtyp, default, metadata, base_schema, typ_frame)
 
     # Generic types
     generic_field = _field_for_generic_type(typ, base_schema, typ_frame, **metadata)
@@ -786,11 +824,10 @@ def field_for_schema(
             metadata=metadata,
             base_schema=base_schema,
             typ_frame=typ_frame,
-            generic_params_to_args=generic_params_to_args,
         )
 
     # enumerations
-    if issubclass(typ, Enum):
+    if inspect.isclass(typ) and issubclass(typ, Enum):
         try:
             return marshmallow.fields.Enum(typ, **metadata)
         except AttributeError:
@@ -811,7 +848,7 @@ def field_for_schema(
         or forward_reference
         or _RECURSION_GUARD.seen_classes.get(typ)
         or _internal_class_schema(
-            typ, base_schema, typ_frame, generic_params_to_args  # type: ignore [arg-type]
+            typ, base_schema, typ_frame  # type: ignore [arg-type]
         )
     )
 
@@ -861,7 +898,7 @@ def _is_generic_alias_of_dataclass(clazz: type) -> bool:
     Check if given class is a generic alias of a dataclass, if the dataclass is
     defined as `class A(Generic[T])`, this method will return true if `A[int]` is passed
     """
-    is_generic = typing_inspect.is_generic_type(clazz)
+    is_generic = is_generic_type(clazz)
     type_arguments = typing_inspect.get_args(clazz)
     origin_class = typing_inspect.get_origin(clazz)
     return (
@@ -871,33 +908,149 @@ def _is_generic_alias_of_dataclass(clazz: type) -> bool:
     )
 
 
-def _generic_params_to_args(clazz: type) -> Tuple[Tuple[type, type], ...]:
-    base_dataclass = typing_inspect.get_origin(clazz)
-    base_parameters = typing_inspect.get_parameters(base_dataclass)
-    type_arguments = typing_inspect.get_args(clazz)
-    return tuple(zip(base_parameters, type_arguments))
-
-
-def _dataclass_type_hints(
-    clazz: type,
+def _get_field_type_hints(
+    field: dataclasses.Field,
     clazz_frame: Optional[types.FrameType] = None,
-    generic_params_to_args: Optional[Tuple[Tuple[type, type], ...]] = None,
-) -> Mapping[str, type]:
+) -> type:
+    """typing.get_type_hints doesn't generic aliasses. But this 'hack' works."""
+
+    class X:
+        x: field.type  # type: ignore[name-defined]
+
     localns = clazz_frame.f_locals if clazz_frame else None
-    if not _is_generic_alias_of_dataclass(clazz):
-        return get_type_hints(clazz, localns=localns)
-    # dataclass is generic
-    generic_type_hints = get_type_hints(typing_inspect.get_origin(clazz), localns)
-    generic_params_map = dict(generic_params_to_args if generic_params_to_args else {})
+    return get_type_hints(X, localns=localns)["x"]
 
-    def _get_hint(_t: type) -> type:
-        if isinstance(_t, TypeVar):
-            return generic_params_map[_t]
-        return _t
 
-    return {
-        field_name: _get_hint(typ) for field_name, typ in generic_type_hints.items()
-    }
+def _is_generic_alias(clazz: type) -> bool:
+    """
+    Check if given class is a generic alias of a class is
+    defined as `class A(Generic[T])`, this method will return true if `A[int]` is passed
+    """
+    is_generic = is_generic_type(clazz)
+    type_arguments = typing_inspect.get_args(clazz)
+    return is_generic and len(type_arguments) > 0
+
+
+def is_generic_type(clazz: type) -> bool:
+    """
+    typing_inspect.is_generic_type explicitly ignores Union, Tuple, Callable, ClassVar
+    """
+    return (
+        isinstance(clazz, type)
+        and issubclass(clazz, Generic)  # type: ignore[arg-type]
+        or isinstance(clazz, typing_inspect.typingGenericAlias)
+    )
+
+
+def _resolve_typevars(clazz: type) -> Dict[type, Dict[TypeVar, _Future]]:
+    """
+    Attemps to resolves all TypeVars in the class bases. Allows us to resolve inherited and aliased generics.
+
+    Returns a dict of each base class and the resolved generics.
+    """
+    # Use Tuples so can zip (order matters)
+    args_by_class: Dict[type, Tuple[Tuple[TypeVar, _Future], ...]] = {}
+    parent_class: Optional[type] = None
+    # Loop in reversed order and iteratively resolve types
+    for subclass in reversed(clazz.mro()):
+        if issubclass(subclass, Generic) and hasattr(subclass, "__orig_bases__"):  # type: ignore[arg-type]
+            args = typing_inspect.get_args(subclass.__orig_bases__[0])
+
+            if parent_class and args_by_class.get(parent_class):
+                subclass_generic_params_to_args: List[Tuple[TypeVar, _Future]] = []
+                for (_arg, future), potential_type in zip(
+                    args_by_class[parent_class], args
+                ):
+                    if isinstance(potential_type, TypeVar):
+                        subclass_generic_params_to_args.append((potential_type, future))
+                    else:
+                        future.set_result(potential_type)
+
+                args_by_class[subclass] = tuple(subclass_generic_params_to_args)
+
+            else:
+                args_by_class[subclass] = tuple((arg, _Future()) for arg in args)
+
+            parent_class = subclass
+
+    # clazz itself is a generic alias i.e.: A[int]. So it hold the last types.
+    if _is_generic_alias(clazz):
+        origin = typing_inspect.get_origin(clazz)
+        args = typing_inspect.get_args(clazz)
+        for (_arg, future), potential_type in zip(args_by_class[origin], args):
+            if not isinstance(potential_type, TypeVar):
+                future.set_result(potential_type)
+
+    # Convert to nested dict for easier lookup
+    return {k: {typ: fut for typ, fut in args} for k, args in args_by_class.items()}
+
+
+def _replace_typevars(
+    clazz: type, resolved_generics: Optional[Dict[TypeVar, _Future]] = None
+) -> type:
+    if not resolved_generics or inspect.isclass(clazz) or not is_generic_type(clazz):
+        return clazz
+
+    return clazz.copy_with(  # type: ignore
+        tuple(
+            (
+                _replace_typevars(arg, resolved_generics)
+                if is_generic_type(arg)
+                else (
+                    resolved_generics[arg].result() if arg in resolved_generics else arg
+                )
+            )
+            for arg in typing_inspect.get_args(clazz)
+        )
+    )
+
+
+def _dataclass_fields(clazz: type) -> Tuple[dataclasses.Field, ...]:
+    if not is_generic_type(clazz):
+        return dataclasses.fields(clazz)
+
+    else:
+        unbound_fields = set()
+        # Need to manually resolve fields because `dataclasses.fields` doesn't handle generics and
+        # looses the source class. Thus I don't know how to resolve this at later on.
+        # Instead we recreate the type but with all known TypeVars resolved to their actual types.
+        resolved_typevars = _resolve_typevars(clazz)
+        # Dict[field_name, Tuple[original_field, resolved_field]]
+        fields: Dict[str, Tuple[dataclasses.Field, dataclasses.Field]] = {}
+
+        for subclass in reversed(clazz.mro()):
+            if not dataclasses.is_dataclass(subclass):
+                continue
+
+            for field in dataclasses.fields(subclass):
+                try:
+                    if field.name in fields and fields[field.name][0] == field:
+                        continue  # identical, so already resolved.
+
+                    # Either the first time we see this field, or it got overridden
+                    # If it's a class we handle it later as a Nested. Nothing to resolve now.
+                    new_field = field
+                    if not inspect.isclass(field.type) and is_generic_type(field.type):
+                        new_field = copy.copy(field)
+                        new_field.type = _replace_typevars(
+                            field.type, resolved_typevars[subclass]
+                        )
+                    elif isinstance(field.type, TypeVar):
+                        new_field = copy.copy(field)
+                        new_field.type = resolved_typevars[subclass][
+                            field.type
+                        ].result()
+
+                    fields[field.name] = (field, new_field)
+                except InvalidStateError:
+                    unbound_fields.add(field.name)
+
+        if unbound_fields:
+            raise UnboundTypeVarError(
+                f"{clazz.__name__} has unbound fields: {', '.join(unbound_fields)}"
+            )
+
+        return tuple(v[1] for v in fields.values())
 
 
 def NewType(

--- a/tests/test_class_schema.py
+++ b/tests/test_class_schema.py
@@ -17,7 +17,7 @@ from marshmallow.fields import Field, Integer
 from marshmallow.fields import List as ListField
 from marshmallow.validate import Validator
 
-from marshmallow_dataclass import NewType, _is_generic_alias_of_dataclass, class_schema
+from marshmallow_dataclass import NewType, class_schema
 
 
 class TestClassSchema(unittest.TestCase):
@@ -459,79 +459,6 @@ class TestClassSchema(unittest.TestCase):
         self.assertNotIn("no_init", class_schema(NoMeta)().fields)
         self.assertNotIn("no_init", class_schema(NoInit)().fields)
         self.assertIn("no_init", class_schema(Init)().fields)
-
-    def test_generic_dataclass(self):
-        T = typing.TypeVar("T")
-
-        @dataclasses.dataclass
-        class SimpleGeneric(typing.Generic[T]):
-            data: T
-
-        @dataclasses.dataclass
-        class NestedFixed:
-            data: SimpleGeneric[int]
-
-        @dataclasses.dataclass
-        class NestedGeneric(typing.Generic[T]):
-            data: SimpleGeneric[T]
-
-        self.assertTrue(_is_generic_alias_of_dataclass(SimpleGeneric[int]))
-        self.assertFalse(_is_generic_alias_of_dataclass(SimpleGeneric))
-
-        schema_s = class_schema(SimpleGeneric[str])()
-        self.assertEqual(SimpleGeneric(data="a"), schema_s.load({"data": "a"}))
-        self.assertEqual(schema_s.dump(SimpleGeneric(data="a")), {"data": "a"})
-        with self.assertRaises(ValidationError):
-            schema_s.load({"data": 2})
-
-        schema_nested = class_schema(NestedFixed)()
-        self.assertEqual(
-            NestedFixed(data=SimpleGeneric(1)),
-            schema_nested.load({"data": {"data": 1}}),
-        )
-        self.assertEqual(
-            schema_nested.dump(NestedFixed(data=SimpleGeneric(data=1))),
-            {"data": {"data": 1}},
-        )
-        with self.assertRaises(ValidationError):
-            schema_nested.load({"data": {"data": "str"}})
-
-        schema_nested_generic = class_schema(NestedGeneric[int])()
-        self.assertEqual(
-            NestedGeneric(data=SimpleGeneric(1)),
-            schema_nested_generic.load({"data": {"data": 1}}),
-        )
-        self.assertEqual(
-            schema_nested_generic.dump(NestedGeneric(data=SimpleGeneric(data=1))),
-            {"data": {"data": 1}},
-        )
-        with self.assertRaises(ValidationError):
-            schema_nested_generic.load({"data": {"data": "str"}})
-
-    def test_generic_dataclass_repeated_fields(self):
-        T = typing.TypeVar("T")
-
-        @dataclasses.dataclass
-        class AA:
-            a: int
-
-        @dataclasses.dataclass
-        class BB(typing.Generic[T]):
-            b: T
-
-        @dataclasses.dataclass
-        class Nested:
-            x: BB[float]
-            z: BB[float]
-            # if y is the first field in this class, deserialisation will fail.
-            # see https://github.com/lovasoa/marshmallow_dataclass/pull/172#issuecomment-1334024027
-            y: BB[AA]
-
-        schema_nested = class_schema(Nested)()
-        self.assertEqual(
-            Nested(x=BB(b=1), z=BB(b=1), y=BB(b=AA(1))),
-            schema_nested.load({"x": {"b": 1}, "z": {"b": 1}, "y": {"b": {"a": 1}}}),
-        )
 
 
 if __name__ == "__main__":

--- a/tests/test_class_schema.py
+++ b/tests/test_class_schema.py
@@ -14,7 +14,7 @@ from marshmallow import Schema, ValidationError
 from marshmallow.fields import Field, UUID as UUIDField, List as ListField, Integer
 from marshmallow.validate import Validator
 
-from marshmallow_dataclass import class_schema, NewType
+from marshmallow_dataclass import class_schema, NewType, _is_generic_alias_of_dataclass
 
 
 class TestClassSchema(unittest.TestCase):

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -1,0 +1,86 @@
+import dataclasses
+import typing
+import unittest
+
+from marshmallow import ValidationError
+
+from marshmallow_dataclass import _is_generic_alias_of_dataclass, class_schema
+
+
+class TestGenerics(unittest.TestCase):
+    def test_generic_dataclass(self):
+        T = typing.TypeVar("T")
+
+        @dataclasses.dataclass
+        class SimpleGeneric(typing.Generic[T]):
+            data: T
+
+        @dataclasses.dataclass
+        class NestedFixed:
+            data: SimpleGeneric[int]
+
+        @dataclasses.dataclass
+        class NestedGeneric(typing.Generic[T]):
+            data: SimpleGeneric[T]
+
+        self.assertTrue(_is_generic_alias_of_dataclass(SimpleGeneric[int]))
+        self.assertFalse(_is_generic_alias_of_dataclass(SimpleGeneric))
+
+        schema_s = class_schema(SimpleGeneric[str])()
+        self.assertEqual(SimpleGeneric(data="a"), schema_s.load({"data": "a"}))
+        self.assertEqual(schema_s.dump(SimpleGeneric(data="a")), {"data": "a"})
+        with self.assertRaises(ValidationError):
+            schema_s.load({"data": 2})
+
+        schema_nested = class_schema(NestedFixed)()
+        self.assertEqual(
+            NestedFixed(data=SimpleGeneric(1)),
+            schema_nested.load({"data": {"data": 1}}),
+        )
+        self.assertEqual(
+            schema_nested.dump(NestedFixed(data=SimpleGeneric(data=1))),
+            {"data": {"data": 1}},
+        )
+        with self.assertRaises(ValidationError):
+            schema_nested.load({"data": {"data": "str"}})
+
+        schema_nested_generic = class_schema(NestedGeneric[int])()
+        self.assertEqual(
+            NestedGeneric(data=SimpleGeneric(1)),
+            schema_nested_generic.load({"data": {"data": 1}}),
+        )
+        self.assertEqual(
+            schema_nested_generic.dump(NestedGeneric(data=SimpleGeneric(data=1))),
+            {"data": {"data": 1}},
+        )
+        with self.assertRaises(ValidationError):
+            schema_nested_generic.load({"data": {"data": "str"}})
+
+    def test_generic_dataclass_repeated_fields(self):
+        T = typing.TypeVar("T")
+
+        @dataclasses.dataclass
+        class AA:
+            a: int
+
+        @dataclasses.dataclass
+        class BB(typing.Generic[T]):
+            b: T
+
+        @dataclasses.dataclass
+        class Nested:
+            x: BB[float]
+            z: BB[float]
+            # if y is the first field in this class, deserialisation will fail.
+            # see https://github.com/lovasoa/marshmallow_dataclass/pull/172#issuecomment-1334024027
+            y: BB[AA]
+
+        schema_nested = class_schema(Nested)()
+        self.assertEqual(
+            Nested(x=BB(b=1), z=BB(b=1), y=BB(b=AA(1))),
+            schema_nested.load({"x": {"b": 1}, "z": {"b": 1}, "y": {"b": {"a": 1}}}),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mypy.yml
+++ b/tests/test_mypy.yml
@@ -6,7 +6,7 @@
     follow_imports = silent
     plugins = marshmallow_dataclass.mypy
     show_error_codes = true
-    python_version = 3.6
+    python_version = 3.8
   env:
     - PYTHONPATH=.
   main: |


### PR DESCRIPTION
Building on the fantastic work of @onursatici and @dairiki in PRs #172 and #232

Currently broken on py3.6, but once #257 is merged I'll rebase and thus remove py3.6 and py3.7 support.


I've tested this with tox on python versions 38, 39, 310, 311, 312