### PR TITLE
Ability to define `child_metadata` on simple List types

### DIFF
--- a/marshmallow_dataclass/__init__.py
+++ b/marshmallow_dataclass/__init__.py
@@ -646,7 +646,10 @@ def _field_for_generic_type(
         type_mapping = base_schema.TYPE_MAPPING if base_schema else {}
 
         if origin in (list, List):
-            child_type = _field_for_schema(arguments[0], base_schema=base_schema)
+            child_metadata = metadata.pop("child_metadata", None)
+            child_type = _field_for_schema(
+                arguments[0], base_schema=base_schema, metadata=child_metadata
+            )
             list_type = cast(
                 Type[marshmallow.fields.List],
                 type_mapping.get(List, marshmallow.fields.List),

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -1,3 +1,6 @@
+from dataclasses import field
+from enum import StrEnum
+from typing import List
 import itertools
 import sys
 import unittest
@@ -277,6 +280,28 @@ class TestSetField(unittest.TestCase):
             SetIntSet(value=frozenset([frozenset([1, 2, 3]), frozenset([123])])),
         )
         self.assertEqualAsSet(schema.dump(loaded), data_in)
+
+    def test_child_metadata(self):
+        """Test child metadata."""
+
+        class Color(StrEnum):
+            RED = "red"
+            GREEN = "green"
+            BLUE = "blue"
+
+        @dataclass
+        class Thing:
+            color: Color = field(metadata={"by_value": True})
+            color_list: List[Color] = field(
+                default_factory=list,
+                metadata=dict(child_metadata=dict(by_value=True)),
+            )
+
+        thing = Thing(
+            color=Color.RED, color_list=[Color.RED, Color.GREEN, Color.BLUE]
+        )  # Example data
+        serialized_thing = Thing.Schema().dump(thing)
+        self.assertEqual(serialized_thing["color_list"], ["red", "green", "blue"])
 
 
 class TestMappingField(unittest.TestCase):


### PR DESCRIPTION
Fixes https://github.com/lovasoa/marshmallow_dataclass/issues/255