### PR TITLE
Ability to override nested class

### DIFF
--- a/marshmallow_dataclass/__init__.py
+++ b/marshmallow_dataclass/__init__.py
@@ -886,7 +886,8 @@ def _field_for_schema(
     forward_reference = getattr(typ, "__forward_arg__", None)
 
     nested = (
-        nested_schema
+        metadata.pop("nested", None)
+        or nested_schema
         or forward_reference
         or _schema_ctx_stack.top.seen_classes.get(typ)
         or _internal_class_schema(typ, base_schema)  # type: ignore[arg-type] # FIXME


### PR DESCRIPTION
I need to override the nested class. This is to use the same object in different presentations.
A simple example would be we have a `User` class.
And we want 2 presentations of it, one as `UserDetails` (this is the User.Schema by default) on an API endpoint.
The other as a `UserEvent`, which has a different schema altogether.

Is this approach ok? I can add tests etc.
