### PR TITLE
Loosen dependency versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     install_requires=[
         "marshmallow>=3.18.0,",
         "typing-inspect>=0.9.0",
-        "typeguard>=4.0.0",
+        "typeguard>=4.0,<5",
         # Need `dataclass_transform(field_specifiers)`
         "typing-extensions>=4.2.0; python_version<'3.11'",
     ],

--- a/setup.py
+++ b/setup.py
@@ -48,8 +48,8 @@ setup(
     python_requires=">=3.8",
     install_requires=[
         "marshmallow>=3.18.0,",
-        "typing-inspect~=0.9.0",
-        "typeguard~=4.0.0",
+        "typing-inspect>=0.9.0",
+        "typeguard>=4.0.0",
         # Need `dataclass_transform(field_specifiers)`
         "typing-extensions>=4.2.0; python_version<'3.11'",
     ],


### PR DESCRIPTION
Fixes #272

The current implementation restricts `typeguard` to `">=4.0.0,<4.1.0"`, preventing the installation of `4.1.3` (which fixes https://github.com/agronholm/typeguard/issues/385)